### PR TITLE
Improve startup probe diagnostics and harden LNB probe detection

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     stlink-tools \
     srecord \
     ca-certificates \
-    gnupg
+    gnupg \
+    kmod
 
 # ---- Mono repository (provides apt nuget on slim images) ----
 # RUN gpg --homedir /tmp --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
@@ -58,7 +59,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # RUN apt update
 
-
+# ---- Local packages ----
+RUN apt-get install -y --no-install-recommends \
+    libicu-dev \
+    usbutils \
+    ripgrep \
+    less \
+    vim \
+    nano \
+    binutils \
+    bash-completion \
+    openssh-client \
+    iproute2 \
+    unzip \
+    # bsdmainutils required for hexdump
+    bsdmainutils \
+    # mono dependencies for MSBuild support
+    libmono-system-drawing4.0-cil \
+    # debug tools
+    openocd \
+    gdb-multiarch \
+    screen \
+    udev \
+    lsof \
+    setserial \
+    picocom \
+    minicom \
+    strace \
+    tio
 
 # ---- GitHub CLI ----
 RUN mkdir -p -m 755 /etc/apt/keyrings \
@@ -89,6 +117,8 @@ RUN groupadd --gid ${USER_GID} ${USERNAME} \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/bash ${USERNAME} \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
     && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+RUN gpasswd -a ${USERNAME} plugdev
 
 # ---- Copy toolchains from downloader ----
 RUN mkdir -p /usr/local/gcc /opt/cmake
@@ -147,34 +177,7 @@ RUN git clone --depth 1 --branch v1.8.5 https://github.com/STMicroelectronics/st
 #  && git clone --depth 1 --branch mbedtls-3.6.5 https://github.com/ARMmbed/mbedtls.git sources/mbedtls \
 #  && cd sources/mbedtls && git submodule update --init --recursive
 
-# ---- Local packages (near the end to allow for faster rebuilds after additions)----
-RUN apt-get install -y --no-install-recommends \
-    libicu-dev \
-    usbutils \
-    ripgrep \
-    less \
-    vim \
-    nano \
-    binutils \
-    bash-completion \
-    openssh-client \
-    iproute2 \
-    unzip \
-    # bsdmainutils required for hexdump
-    bsdmainutils \
-    # mono dependencies for MSBuild support
-    libmono-system-drawing4.0-cil \
-    # debug tools
-    openocd \
-    gdb-multiarch \
-    screen \
-    udev \
-    lsof \
-    setserial \
-    picocom \
-    minicom \
-    strace \
-    tio
+
 
 # ---- Final cleanup ----
 RUN apt-get autoremove -y && apt-get clean

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,9 +51,9 @@
 	"runArgs": [
 	    "--hostname=cubley-dev",
 		// Need privileged mode to access USB devices, as /dev/bus/usb may not appear if there are no shared devices.
-		"--privileged"
+		"--privileged",
 		// "--device=/dev/bus/usb:/dev/bus/usb",
-		// "--device=/dev/ttyUSB0:/dev/ttyUSB0",
+		"--device=/dev/ttyUSB0:/dev/ttyUSB0",
 		// "--device=/dev/ttyACM0:/dev/ttyACM0"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/software/nanoFramework/DiSEqC_Control/StartupProbe.cs
+++ b/software/nanoFramework/DiSEqC_Control/StartupProbe.cs
@@ -12,10 +12,11 @@ namespace DiSEqC_Control
         private const int LedPin = 2;
         private const int LnbBusId = 1;
         private const int LnbAddress = 0x08;
+        private const int LnbSentinelEmptyAddress = 0x7A;
         private const int FramBusId = 3;
         private const int FramAddress = 0x50;
-        private static bool ProbeW5500OnStartup = false;
-        private static bool ProbeFramOnStartup = false;
+        private static bool ProbeW5500OnStartup = true;
+        private static bool ProbeFramOnStartup = true;
 
         private const uint ProbeStageBase = 0xD5E10000u;
         private const uint ProbeStageW5500 = 0x0100u;
@@ -140,23 +141,58 @@ namespace DiSEqC_Control
 
         private static bool ProbeLnbh26()
         {
-            I2cDevice device = null;
+            byte lnbStatus = 0;
+            byte sentinelValue = 0;
 
             try
             {
-                device = new I2cDevice(new I2cConnectionSettings(LnbBusId, LnbAddress));
+                if (!TryReadI2cRegisterByte(LnbBusId, LnbAddress, 0x01, out lnbStatus))
+                {
+                    Debug.WriteLine("[probe] LNBH26 I2C" + LnbBusId + " addr=0x" + LnbAddress.ToString("X2") + " present=false (no ACK/read failure)");
+                    return false;
+                }
 
-                // Probe by reading status register (0x01); ACK on address+register is sufficient for presence.
-                byte[] reg = new byte[1] { 0x01 };
-                byte[] status = new byte[1];
-                device.WriteRead(reg, status);
+                // LNBH26 status register uses only low 3 bits.
+                if ((lnbStatus & 0xF8) != 0)
+                {
+                    Debug.WriteLine("[probe] LNBH26 status=0x" + lnbStatus.ToString("X2") + " invalid bit pattern; treating as absent");
+                    return false;
+                }
 
-                Debug.WriteLine("[probe] LNBH26 I2C" + LnbBusId + " addr=0x" + LnbAddress.ToString("X2") + " present=true");
+                // If an intentionally empty sentinel address also ACKs on the same bus,
+                // the bus/probe path is likely unreliable for presence detection.
+                if (TryReadI2cRegisterByte(LnbBusId, LnbSentinelEmptyAddress, 0x00, out sentinelValue))
+                {
+                    Debug.WriteLine("[probe] LNBH26 false-positive guard tripped: sentinel addr 0x" + LnbSentinelEmptyAddress.ToString("X2") + " also ACKed (value=0x" + sentinelValue.ToString("X2") + ")");
+                    return false;
+                }
+
+                Debug.WriteLine("[probe] LNBH26 I2C" + LnbBusId + " addr=0x" + LnbAddress.ToString("X2") + " status=0x" + lnbStatus.ToString("X2") + " present=true");
                 return true;
             }
             catch (Exception ex)
             {
                 Debug.WriteLine("[probe] LNBH26 exception: " + ex.Message);
+                return false;
+            }
+        }
+
+        private static bool TryReadI2cRegisterByte(int busId, int address, byte reg, out byte value)
+        {
+            I2cDevice device = null;
+            value = 0;
+
+            try
+            {
+                device = new I2cDevice(new I2cConnectionSettings(busId, address));
+                byte[] writeBuffer = new byte[1] { reg };
+                byte[] readBuffer = new byte[1];
+                device.WriteRead(writeBuffer, readBuffer);
+                value = readBuffer[0];
+                return true;
+            }
+            catch
+            {
                 return false;
             }
             finally

--- a/software/nanoFramework/tests/swd_read_bringup_status.sh
+++ b/software/nanoFramework/tests/swd_read_bringup_status.sh
@@ -15,6 +15,11 @@ else
   GDB_BIN="gdb"
 fi
 OPENOCD_BIN="${OPENOCD_BIN:-openocd}"
+STARTUP_PROBE_CS="${STARTUP_PROBE_CS:-$NF_ROOT/DiSEqC_Control/StartupProbe.cs}"
+
+# Allow override from environment; auto-detect from StartupProbe.cs when available.
+probe_w5500_on_startup="${PROBE_W5500_ON_STARTUP:-auto}"
+probe_fram_on_startup="${PROBE_FRAM_ON_STARTUP:-auto}"
 
 if [[ ! -f "$ELF_PATH" ]]; then
   echo "ELF not found: $ELF_PATH" >&2
@@ -29,6 +34,24 @@ fi
 if ! command -v "$GDB_BIN" >/dev/null 2>&1; then
   echo "arm-none-eabi-gdb not found (override with GDB_BIN)." >&2
   exit 1
+fi
+
+if [[ -f "$STARTUP_PROBE_CS" ]]; then
+  if [[ "$probe_w5500_on_startup" == "auto" ]]; then
+    if grep -Eq 'ProbeW5500OnStartup\s*=\s*true' "$STARTUP_PROBE_CS"; then
+      probe_w5500_on_startup="true"
+    elif grep -Eq 'ProbeW5500OnStartup\s*=\s*false' "$STARTUP_PROBE_CS"; then
+      probe_w5500_on_startup="false"
+    fi
+  fi
+
+  if [[ "$probe_fram_on_startup" == "auto" ]]; then
+    if grep -Eq 'ProbeFramOnStartup\s*=\s*true' "$STARTUP_PROBE_CS"; then
+      probe_fram_on_startup="true"
+    elif grep -Eq 'ProbeFramOnStartup\s*=\s*false' "$STARTUP_PROBE_CS"; then
+      probe_fram_on_startup="false"
+    fi
+  fi
 fi
 
 tmp_dir="$(mktemp -d /tmp/w5500-mailbox-XXXXXX)"
@@ -89,6 +112,7 @@ fi
 decode_word() {
   local label="$1"
   local value_hex="$2"
+  local is_boot_probe=0
   local value_dec=$((value_hex))
   local magic=$(((value_dec >> 24) & 0xFF))
   local stage=$(((value_dec >> 16) & 0xFF))
@@ -107,24 +131,47 @@ decode_word() {
   printf '%s raw: %s\n' "$label" "$value_hex"
   printf '  Magic: 0x%02X\n' "$magic"
   printf '  Stage: %d\n' "$stage"
-  printf '  Result: %d (%s)\n' "$result" "$result_label"
+  if [[ "$label" == "Boot probe" && "$magic" -eq 213 && "$stage" -eq 226 ]]; then
+    is_boot_probe=1
+    printf '  Result: %d (bitmap payload; not a pass/fail field for boot probe)\n' "$result"
+  else
+    printf '  Result: %d (%s)\n' "$result" "$result_label"
+  fi
   printf '  Detail: %d\n' "$detail"
 
   if [[ "$magic" -ne 0 && "$magic" -ne 213 ]]; then
     echo "  Warning: magic byte mismatch (expected 0xD5)." >&2
   fi
 
-  if [[ "$label" == "Boot probe" && "$magic" -eq 213 && "$stage" -eq 226 ]]; then
-    local has_w5500="absent"
-    local has_lnb="absent"
-    local has_fram="absent"
+  if [[ "$is_boot_probe" -eq 1 ]]; then
+    local has_w5500="detected"
+    local has_lnb="detected"
+    local has_fram="detected"
 
-    if (( detail & 0x01 )); then has_w5500="present"; fi
-    if (( detail & 0x02 )); then has_lnb="present"; fi
-    if (( detail & 0x04 )); then has_fram="present"; fi
+    if (( (detail & 0x01) == 0 )); then
+      if [[ "$probe_w5500_on_startup" == "false" ]]; then
+        has_w5500="skipped-by-firmware-config"
+      else
+        has_w5500="not-detected"
+      fi
+    fi
 
-    printf '  Hardware: W5500=%s LNBH26=%s FRAM=%s\n' "$has_w5500" "$has_lnb" "$has_fram"
+    if (( (detail & 0x02) == 0 )); then
+      has_lnb="not-detected"
+    fi
+
+    if (( (detail & 0x04) == 0 )); then
+      if [[ "$probe_fram_on_startup" == "false" ]]; then
+        has_fram="skipped-by-firmware-config"
+      else
+        has_fram="not-detected"
+      fi
+    fi
+
+    printf '  Hardware bitmap: W5500=%s LNBH26=%s FRAM=%s\n' "$has_w5500" "$has_lnb" "$has_fram"
     printf '  Bitmap decode: bit0=W5500 bit1=LNBH26 bit2=FRAM\n'
+    printf '  Probe config: W5500=%s FRAM=%s (source: %s)\n' "$probe_w5500_on_startup" "$probe_fram_on_startup" "$STARTUP_PROBE_CS"
+    printf '  Note: LNBH26=detected means the startup I2C probe got ACK at bus1 addr 0x08; if the chip is absent this suggests an address/bus mismatch or a false-positive ACK path.\n'
   fi
 }
 


### PR DESCRIPTION
## Summary
- improve SWD bring-up status decoding for boot-probe mailbox words
- distinguish skipped-by-firmware-config from not-detected in hardware bitmap output
- harden managed LNB presence probe to reduce false positives
- enable startup probes for W5500 and FRAM for active detection
- include current devcontainer updates present in the working tree

## Validation
- compiled managed project via build-managed compile/build flows
- deployed managed bundle via SWD
- verified bring-up mailbox output with tests/swd_read_bringup_status.sh