### PR TITLE
Add interop CI guard and enforce native-only Cubley.Interop

### DIFF
--- a/.github/skills/pr-body-format/SKILL.md
+++ b/.github/skills/pr-body-format/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: pr-body-format
+description: "Use when creating or editing GitHub pull request descriptions so Markdown renders correctly every time. Keywords: PR summary format, gh pr create body, gh pr edit body, escaped newline issue, body-file template."
+---
+
+# PR Body Format
+
+## Purpose
+
+Ensure PR descriptions are consistently well-formed Markdown by using a real body file, never escaped newline strings.
+
+## Primary Targets
+
+- Pull request description fields created with `gh pr create` or updated with `gh pr edit`
+- Temporary body file in `/tmp` (for example `/tmp/pr_body.md`)
+
+## When To Use
+
+- Any time creating a PR from the terminal.
+- Any time fixing a malformed PR body that shows literal `\\n` sequences.
+- Any time a PR needs standardized sections for summary and validation.
+
+## Workflow
+
+1. Build the PR body in a heredoc file with literal newlines:
+   - `cat > /tmp/pr_body.md <<'EOF'`
+   - Write headings and bullets as normal Markdown.
+   - `EOF`
+2. Create or edit PR using `--body-file`:
+   - create: `gh pr create --base <base> --head <branch> --title "..." --body-file /tmp/pr_body.md`
+   - edit: `gh pr edit <number> --body-file /tmp/pr_body.md`
+3. Verify rendered content source is clean:
+   - `gh pr view <number> --json body`
+   - Confirm the body contains real line breaks and no literal `\\n` text.
+
+## Required Template
+
+Use this structure unless the user asks for a different format:
+
+```markdown
+## Summary
+- Change 1.
+- Change 2.
+- Change 3.
+
+## Validation
+- `command 1`
+- `command 2`
+- `command 3`
+```
+
+## Output Format
+
+- "PR body update: SUCCESS" or "PR body update: FAILED"
+- Include PR URL and a one-line statement that formatting was verified.
+
+## Guardrails
+
+- Do not pass multiline bodies with escaped `\n` in a single shell string.
+- Prefer sentence-case bullets ending with periods.
+- Keep sections short and factual.
+- Preserve user-provided wording when possible; only normalize formatting unless asked to rewrite content.

--- a/.github/workflows/interop-guard.yml
+++ b/.github/workflows/interop-guard.yml
@@ -4,18 +4,22 @@ on:
   pull_request:
     paths:
       - software/nanoFramework/Cubley.Interop/**
+      - software/nanoFramework/DiSEqC_Control/Native/**
       - software/nanoFramework/nf-native/cubley_interop.cpp
       - software/nanoFramework/toolchain/interop-checksum.sh
       - software/nanoFramework/toolchain/interop-guard.sh
+      - software/nanoFramework/tests/DiSEqC_Control.Tests/**
       - .github/workflows/interop-guard.yml
   push:
     branches:
       - main
     paths:
       - software/nanoFramework/Cubley.Interop/**
+      - software/nanoFramework/DiSEqC_Control/Native/**
       - software/nanoFramework/nf-native/cubley_interop.cpp
       - software/nanoFramework/toolchain/interop-checksum.sh
       - software/nanoFramework/toolchain/interop-guard.sh
+      - software/nanoFramework/tests/DiSEqC_Control.Tests/**
       - .github/workflows/interop-guard.yml
 
 jobs:
@@ -33,3 +37,8 @@ jobs:
           cd software/nanoFramework
           ./toolchain/interop-checksum.sh --check
           ./toolchain/interop-guard.sh
+
+      - name: Run host-side interop contract tests
+        run: |
+          cd software/nanoFramework/tests/DiSEqC_Control.Tests
+          dotnet test --configuration Release --nologo --filter "FullyQualifiedName~ContractTests"

--- a/.github/workflows/interop-guard.yml
+++ b/.github/workflows/interop-guard.yml
@@ -1,0 +1,50 @@
+name: Interop Guard
+
+on:
+  pull_request:
+    paths:
+      - software/nanoFramework/Cubley.Interop/**
+      - software/nanoFramework/nf-native/cubley_interop.cpp
+      - software/nanoFramework/toolchain/interop-checksum.sh
+      - software/nanoFramework/toolchain/interop-guard.sh
+      - .github/workflows/interop-guard.yml
+  push:
+    branches:
+      - main
+    paths:
+      - software/nanoFramework/Cubley.Interop/**
+      - software/nanoFramework/nf-native/cubley_interop.cpp
+      - software/nanoFramework/toolchain/interop-checksum.sh
+      - software/nanoFramework/toolchain/interop-guard.sh
+      - .github/workflows/interop-guard.yml
+
+jobs:
+  managed-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build managed project
+        run: |
+          cd software/nanoFramework
+          ./toolchain/build-managed.sh compile --project DiSEqC_Control/DiSEqC_Control.nfproj
+
+  interop-guard:
+    needs: managed-build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify Cubley interop mapping
+        run: |
+          cd software/nanoFramework
+          ./toolchain/interop-checksum.sh --check
+          ./toolchain/interop-guard.sh

--- a/.github/workflows/interop-guard.yml
+++ b/.github/workflows/interop-guard.yml
@@ -19,22 +19,7 @@ on:
       - .github/workflows/interop-guard.yml
 
 jobs:
-  managed-build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build managed project
-        run: |
-          cd software/nanoFramework
-          ./toolchain/build-managed.sh compile --project DiSEqC_Control/DiSEqC_Control.nfproj
-
   interop-guard:
-    needs: managed-build
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/software/nanoFramework/Cubley.Interop/CubleyInteropNative.cs
+++ b/software/nanoFramework/Cubley.Interop/CubleyInteropNative.cs
@@ -79,85 +79,28 @@ namespace Cubley.Interop
         public enum Band { Low = 0, High = 1 }
         public enum Status { Ok = 0, InvalidParam = 1, NotInitialized = 2, IoError = 3 }
 
-        public static Status Init()
-        {
-            int result = NativeInit();
-            return (Status)result;
-        }
-
-        public static Status SetEnable(bool enable)
-        {
-            int result = NativeSetEnable(enable);
-            return (Status)result;
-        }
-
-        public static Status ReadStatus(out int statusRegister)
-        {
-            int result = NativeReadStatus(out statusRegister);
-            return (Status)result;
-        }
-
-        public static Status SetVoltage(Voltage voltage)
-        {
-            int result = NativeSetVoltage((int)voltage);
-            return (Status)result;
-        }
-        public static Status SetPolarization(Polarization polarization)
-        {
-            int result = NativeSetPolarization((int)polarization);
-            return (Status)result;
-        }
-        public static Status SetTone(bool enable)
-        {
-            int result = NativeSetTone(enable);
-            return (Status)result;
-        }
-        public static Status SetBand(Band band)
-        {
-            int result = NativeSetBand((int)band);
-            return (Status)result;
-        }
-        public static Voltage GetVoltage()
-        {
-            int result = NativeGetVoltage();
-            return (Voltage)result;
-        }
-        public static bool GetTone()
-        {
-            return NativeGetTone();
-        }
-        public static Polarization GetPolarization()
-        {
-            int result = NativeGetPolarization();
-            return (Polarization)result;
-        }
-        public static Band GetBand()
-        {
-            int result = NativeGetBand();
-            return (Band)result;
-        }
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeInit();
+        public static extern int NativeInit();
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetEnable(bool enable);
+        public static extern int NativeSetEnable(bool enable);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeReadStatus(out int statusRegister);
+        public static extern int NativeReadStatus(out int statusRegister);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetVoltage(int voltage);
+        public static extern int NativeSetVoltage(int voltage);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetPolarization(int polarization);
+        public static extern int NativeSetPolarization(int polarization);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetTone(bool enable);
+        public static extern int NativeSetTone(bool enable);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetBand(int band);
+        public static extern int NativeSetBand(int band);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeGetVoltage();
+        public static extern int NativeGetVoltage();
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool NativeGetTone();
+        public static extern bool NativeGetTone();
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeGetPolarization();
+        public static extern int NativeGetPolarization();
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeGetBand();
+        public static extern int NativeGetBand();
     }
 
     public static class StatusLed

--- a/software/nanoFramework/Cubley.Interop/Properties/AssemblyInfo.cs
+++ b/software/nanoFramework/Cubley.Interop/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyNativeVersion("2F4C7DCD")]
+[assembly: AssemblyNativeVersion("C5EF91C9")]

--- a/software/nanoFramework/DiSEqC_Control/DiSEqC_Control.nfproj
+++ b/software/nanoFramework/DiSEqC_Control/DiSEqC_Control.nfproj
@@ -29,7 +29,7 @@
     <Compile Include="HardwareCapabilities.cs" />
     <!-- <Compile Include="Manager\RotorManagerNative.cs" /> -->
     <!-- <Compile Include="Native\DiSEqCNative.cs" /> -->
-    <!-- <Compile Include="Native\LNBNative.cs" /> -->
+    <Compile Include="Native\LNBNative.cs" />
     <Compile Include="Native\W5500SocketNative.cs" />
     <Compile Include="Mqtt\AsciiCodec.cs" />
     <Compile Include="Mqtt\IMqttCommandSink.cs" />

--- a/software/nanoFramework/DiSEqC_Control/Native/LNBNative.cs
+++ b/software/nanoFramework/DiSEqC_Control/Native/LNBNative.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Runtime.CompilerServices;
+using CubleyLnb = Cubley.Interop.LNBH26;
 
 namespace DiSEqC_Control.Native
 {
@@ -43,7 +42,23 @@ namespace DiSEqC_Control.Native
         {
             Ok = 0,
             InvalidParam = 1,
-            NotInitialized = 2
+            NotInitialized = 2,
+            IoError = 3
+        }
+
+        public static Status Init()
+        {
+            return (Status)CubleyLnb.NativeInit();
+        }
+
+        public static Status SetEnable(bool enable)
+        {
+            return (Status)CubleyLnb.NativeSetEnable(enable);
+        }
+
+        public static Status ReadStatus(out int statusRegister)
+        {
+            return (Status)CubleyLnb.NativeReadStatus(out statusRegister);
         }
 
         /// <summary>
@@ -53,8 +68,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Status code</returns>
         public static Status SetVoltage(Voltage voltage)
         {
-            int result = NativeSetVoltage((int)voltage);
-            return (Status)result;
+            return (Status)CubleyLnb.NativeSetVoltage((int)voltage);
         }
 
         /// <summary>
@@ -64,8 +78,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Status code</returns>
         public static Status SetPolarization(Polarization polarization)
         {
-            int result = NativeSetPolarization((int)polarization);
-            return (Status)result;
+            return (Status)CubleyLnb.NativeSetPolarization((int)polarization);
         }
 
         /// <summary>
@@ -75,8 +88,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Status code</returns>
         public static Status SetTone(bool enable)
         {
-            int result = NativeSetTone(enable);
-            return (Status)result;
+            return (Status)CubleyLnb.NativeSetTone(enable);
         }
 
         /// <summary>
@@ -86,8 +98,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Status code</returns>
         public static Status SetBand(Band band)
         {
-            int result = NativeSetBand((int)band);
-            return (Status)result;
+            return (Status)CubleyLnb.NativeSetBand((int)band);
         }
 
         /// <summary>
@@ -96,8 +107,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Current voltage</returns>
         public static Voltage GetVoltage()
         {
-            int result = NativeGetVoltage();
-            return (Voltage)result;
+            return (Voltage)CubleyLnb.NativeGetVoltage();
         }
 
         /// <summary>
@@ -106,7 +116,7 @@ namespace DiSEqC_Control.Native
         /// <returns>True if tone is enabled</returns>
         public static bool GetTone()
         {
-            return NativeGetTone();
+            return CubleyLnb.NativeGetTone();
         }
 
         /// <summary>
@@ -115,8 +125,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Current polarization</returns>
         public static Polarization GetPolarization()
         {
-            int result = NativeGetPolarization();
-            return (Polarization)result;
+            return (Polarization)CubleyLnb.NativeGetPolarization();
         }
 
         /// <summary>
@@ -125,33 +134,7 @@ namespace DiSEqC_Control.Native
         /// <returns>Current band</returns>
         public static Band GetBand()
         {
-            int result = NativeGetBand();
-            return (Band)result;
+            return (Band)CubleyLnb.NativeGetBand();
         }
-
-        /* Native method declarations */
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetVoltage(int voltage);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetPolarization(int polarization);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetTone(bool enable);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeSetBand(int band);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeGetVoltage();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool NativeGetTone();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeGetPolarization();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int NativeGetBand();
     }
 }

--- a/software/nanoFramework/DiSEqC_Control/Program.cs
+++ b/software/nanoFramework/DiSEqC_Control/Program.cs
@@ -874,11 +874,11 @@ namespace DiSEqC_Control
         }
 
         /// <summary>
-        /// Basic I2C communication test for LNBH25PQR
+        /// Basic I2C communication test for LNBH26
         /// </summary>
         private static void LnbI2cBasicTest()
         {
-            Debug.WriteLine("\n--- LNBH25PQR I2C Basic Test ---");
+            Debug.WriteLine("\n--- LNBH26 I2C Basic Test ---");
             var status = LNBH26.SetVoltage(LNBH26.Voltage.V13);
             Debug.WriteLine($"SetVoltage(13V) result: {status}");
             var voltage = LNBH26.GetVoltage();

--- a/software/nanoFramework/DiSEqC_Control/Program.cs
+++ b/software/nanoFramework/DiSEqC_Control/Program.cs
@@ -427,29 +427,29 @@ namespace DiSEqC_Control
 
             try
             {
-                Cubley.Interop.LNBH26.Status status = Cubley.Interop.LNBH26.Init();
-                if (status != Cubley.Interop.LNBH26.Status.Ok)
+                LNBH26.Status status = LNBH26.Init();
+                if (status != LNBH26.Status.Ok)
                 {
                     Debug.WriteLine("[LNB] Init failed: " + status);
                     return false;
                 }
 
-                status = Cubley.Interop.LNBH26.SetEnable(true);
-                if (status != Cubley.Interop.LNBH26.Status.Ok)
+                status = LNBH26.SetEnable(true);
+                if (status != LNBH26.Status.Ok)
                 {
                     Debug.WriteLine("[LNB] SetEnable(true) failed: " + status);
                     return false;
                 }
 
-                status = Cubley.Interop.LNBH26.SetVoltage(Cubley.Interop.LNBH26.Voltage.V13);
-                if (status != Cubley.Interop.LNBH26.Status.Ok)
+                status = LNBH26.SetVoltage(LNBH26.Voltage.V13);
+                if (status != LNBH26.Status.Ok)
                 {
                     Debug.WriteLine("[LNB] SetVoltage(13V) failed: " + status);
                     return false;
                 }
 
-                status = Cubley.Interop.LNBH26.SetTone(false);
-                if (status != Cubley.Interop.LNBH26.Status.Ok)
+                status = LNBH26.SetTone(false);
+                if (status != LNBH26.Status.Ok)
                 {
                     Debug.WriteLine("[LNB] SetTone(false) failed: " + status);
                     return false;
@@ -488,14 +488,14 @@ namespace DiSEqC_Control
                 return;
             }
 
-            PublishStatusInternal("lnb/voltage", Cubley.Interop.LNBH26.GetVoltage() == Cubley.Interop.LNBH26.Voltage.V18 ? "18" : "13");
-            PublishStatusInternal("lnb/tone", Cubley.Interop.LNBH26.GetTone() ? "on" : "off");
-            PublishStatusInternal("lnb/polarization", Cubley.Interop.LNBH26.GetPolarization() == Cubley.Interop.LNBH26.Polarization.Horizontal ? "horizontal" : "vertical");
-            PublishStatusInternal("lnb/band", Cubley.Interop.LNBH26.GetBand() == Cubley.Interop.LNBH26.Band.High ? "high" : "low");
+            PublishStatusInternal("lnb/voltage", LNBH26.GetVoltage() == LNBH26.Voltage.V18 ? "18" : "13");
+            PublishStatusInternal("lnb/tone", LNBH26.GetTone() ? "on" : "off");
+            PublishStatusInternal("lnb/polarization", LNBH26.GetPolarization() == LNBH26.Polarization.Horizontal ? "horizontal" : "vertical");
+            PublishStatusInternal("lnb/band", LNBH26.GetBand() == LNBH26.Band.High ? "high" : "low");
 
             int statusReg;
-            Cubley.Interop.LNBH26.Status status = Cubley.Interop.LNBH26.ReadStatus(out statusReg);
-            if (status == Cubley.Interop.LNBH26.Status.Ok)
+            LNBH26.Status status = LNBH26.ReadStatus(out statusReg);
+            if (status == LNBH26.Status.Ok)
             {
                 PublishStatusInternal("lnb/status_raw", "0x" + statusReg.ToString("X2"));
             }
@@ -515,9 +515,9 @@ namespace DiSEqC_Control
             return TryInitializeLnbControl();
         }
 
-        private static bool TryApplyLnbOperation(Cubley.Interop.LNBH26.Status status, string context)
+        private static bool TryApplyLnbOperation(LNBH26.Status status, string context)
         {
-            if (status != Cubley.Interop.LNBH26.Status.Ok)
+            if (status != LNBH26.Status.Ok)
             {
                 PublishErrorInternal(context + ": " + status);
                 return false;
@@ -661,15 +661,15 @@ namespace DiSEqC_Control
             }
 
             string normalized = NormalizePayload(payload);
-            Cubley.Interop.LNBH26.Voltage voltage;
+            LNBH26.Voltage voltage;
 
             if (normalized == "13" || normalized == "13v" || normalized == "v" || normalized == "vertical")
             {
-                voltage = Cubley.Interop.LNBH26.Voltage.V13;
+                voltage = LNBH26.Voltage.V13;
             }
             else if (normalized == "18" || normalized == "18v" || normalized == "h" || normalized == "horizontal")
             {
-                voltage = Cubley.Interop.LNBH26.Voltage.V18;
+                voltage = LNBH26.Voltage.V18;
             }
             else
             {
@@ -677,7 +677,7 @@ namespace DiSEqC_Control
                 return;
             }
 
-            TryApplyLnbOperation(Cubley.Interop.LNBH26.SetVoltage(voltage), "lnb/voltage");
+            TryApplyLnbOperation(LNBH26.SetVoltage(voltage), "lnb/voltage");
         }
 
         public void HandleLnbPolarization(string payload)
@@ -695,15 +695,15 @@ namespace DiSEqC_Control
             }
 
             string normalized = NormalizePayload(payload);
-            Cubley.Interop.LNBH26.Polarization polarization;
+            LNBH26.Polarization polarization;
 
             if (normalized == "vertical" || normalized == "v" || normalized == "13" || normalized == "13v")
             {
-                polarization = Cubley.Interop.LNBH26.Polarization.Vertical;
+                polarization = LNBH26.Polarization.Vertical;
             }
             else if (normalized == "horizontal" || normalized == "h" || normalized == "18" || normalized == "18v")
             {
-                polarization = Cubley.Interop.LNBH26.Polarization.Horizontal;
+                polarization = LNBH26.Polarization.Horizontal;
             }
             else
             {
@@ -711,7 +711,7 @@ namespace DiSEqC_Control
                 return;
             }
 
-            TryApplyLnbOperation(Cubley.Interop.LNBH26.SetPolarization(polarization), "lnb/polarization");
+            TryApplyLnbOperation(LNBH26.SetPolarization(polarization), "lnb/polarization");
         }
 
         public void HandleLnbTone(string payload)
@@ -745,7 +745,7 @@ namespace DiSEqC_Control
                 return;
             }
 
-            TryApplyLnbOperation(Cubley.Interop.LNBH26.SetTone(enable), "lnb/tone");
+            TryApplyLnbOperation(LNBH26.SetTone(enable), "lnb/tone");
         }
 
         public void HandleLnbBand(string payload)
@@ -763,15 +763,15 @@ namespace DiSEqC_Control
             }
 
             string normalized = NormalizePayload(payload);
-            Cubley.Interop.LNBH26.Band band;
+            LNBH26.Band band;
 
             if (normalized == "low" || normalized == "0")
             {
-                band = Cubley.Interop.LNBH26.Band.Low;
+                band = LNBH26.Band.Low;
             }
             else if (normalized == "high" || normalized == "1")
             {
-                band = Cubley.Interop.LNBH26.Band.High;
+                band = LNBH26.Band.High;
             }
             else
             {
@@ -779,7 +779,7 @@ namespace DiSEqC_Control
                 return;
             }
 
-            TryApplyLnbOperation(Cubley.Interop.LNBH26.SetBand(band), "lnb/band");
+            TryApplyLnbOperation(LNBH26.SetBand(band), "lnb/band");
         }
         public void HandleCalibrateReference() { PublishErrorInternal("calibration not yet bound"); }
 
@@ -879,9 +879,9 @@ namespace DiSEqC_Control
         private static void LnbI2cBasicTest()
         {
             Debug.WriteLine("\n--- LNBH25PQR I2C Basic Test ---");
-            var status = Cubley.Interop.LNBH26.SetVoltage(Cubley.Interop.LNBH26.Voltage.V13);
+            var status = LNBH26.SetVoltage(LNBH26.Voltage.V13);
             Debug.WriteLine($"SetVoltage(13V) result: {status}");
-            var voltage = Cubley.Interop.LNBH26.GetVoltage();
+            var voltage = LNBH26.GetVoltage();
             Debug.WriteLine($"GetVoltage() -> {voltage}");
             // Optionally, print more status if available
         }

--- a/software/nanoFramework/DiSEqC_Control/StartupProbe.cs
+++ b/software/nanoFramework/DiSEqC_Control/StartupProbe.cs
@@ -115,27 +115,9 @@ namespace DiSEqC_Control
             {
                 Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x02u);
 
-                // Non-BYREF sanity call first: helps isolate whether stall is generic interop
-                // entry for W5500 class or specific to NativeOpen(out int).
-                uint preVersion = Cubley.Interop.W5500Socket.NativeGetVersion();
-                Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x03u);
-
-                int socketHandle;
-                int openStatus = Cubley.Interop.W5500Socket.NativeOpen(out socketHandle);
-                Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x04u);
-                if (openStatus != (int)Cubley.Interop.W5500Socket.Status.Ok)
-                {
-                    Debug.WriteLine("[probe] W5500 pre_version=0x" + preVersion.ToString("X2") + " open_status=" + openStatus + " present=false");
-                    return false;
-                }
-
                 uint version = Cubley.Interop.W5500Socket.NativeGetVersion();
+                Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x03u);
                 bool present = (version & 0xFFu) == 0x04u;
-
-                if (socketHandle >= 0)
-                {
-                    Cubley.Interop.W5500Socket.NativeClose(socketHandle);
-                }
 
                 Debug.WriteLine("[probe] W5500 version=0x" + version.ToString("X2") + " present=" + present);
                 return present;

--- a/software/nanoFramework/DiSEqC_Control/StartupProbe.cs
+++ b/software/nanoFramework/DiSEqC_Control/StartupProbe.cs
@@ -113,11 +113,19 @@ namespace DiSEqC_Control
         {
             try
             {
+                Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x02u);
+
+                // Non-BYREF sanity call first: helps isolate whether stall is generic interop
+                // entry for W5500 class or specific to NativeOpen(out int).
+                uint preVersion = Cubley.Interop.W5500Socket.NativeGetVersion();
+                Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x03u);
+
                 int socketHandle;
                 int openStatus = Cubley.Interop.W5500Socket.NativeOpen(out socketHandle);
+                Cubley.Interop.BringupStatus.NativeSet(ProbeStageBase | ProbeStageW5500 | 0x04u);
                 if (openStatus != (int)Cubley.Interop.W5500Socket.Status.Ok)
                 {
-                    Debug.WriteLine("[probe] W5500 open_status=" + openStatus + " present=false");
+                    Debug.WriteLine("[probe] W5500 pre_version=0x" + preVersion.ToString("X2") + " open_status=" + openStatus + " present=false");
                     return false;
                 }
 

--- a/software/nanoFramework/nf-native/cubley_interop.cpp
+++ b/software/nanoFramework/nf-native/cubley_interop.cpp
@@ -60,13 +60,13 @@ static const CLR_RT_MethodHandler method_lookup[] =
     Library_cubley_interop_DiagnosticsMailbox_NativeTryLatchBootProbe___STATIC__BOOLEAN__U4, // [3] DiagnosticsMailbox.NativeTryLatchBootProbe
     Library_cubley_interop_DiagnosticsMailbox_NativeGetBootProbe___STATIC__U4, // [4] DiagnosticsMailbox.NativeGetBootProbe
     Library_cubley_interop_W5500Socket_NativeOpen___STATIC__I4__BYREF_I4,   // [5] W5500Socket.NativeOpen
-    Library_cubley_interop_W5500Socket_NativeConfigureNetwork___STATIC__I4__STRING__STRING__STRING__STRING, // [6]
-    Library_cubley_interop_W5500Socket_NativeConnect___STATIC__I4__I4__STRING__I4__I4,                     // [7]
-    Library_cubley_interop_W5500Socket_NativeSend___STATIC__I4__I4__SZARRAY_U1__I4__I4__BYREF_I4,          // [8]
-    Library_cubley_interop_W5500Socket_NativeReceive___STATIC__I4__I4__SZARRAY_U1__I4__I4__I4__BYREF_I4,   // [9]
+    Library_cubley_interop_W5500Socket_NativeConfigureNetwork___STATIC__I4__STRING__STRING__STRING__STRING, // [6] W5500Socket.NativeConfigureNetwork
+    Library_cubley_interop_W5500Socket_NativeConnect___STATIC__I4__I4__STRING__I4__I4,                     // [7] W5500Socket.NativeConnect
+    Library_cubley_interop_W5500Socket_NativeSend___STATIC__I4__I4__SZARRAY_U1__I4__I4__BYREF_I4,          // [8] W5500Socket.NativeSend
+    Library_cubley_interop_W5500Socket_NativeReceive___STATIC__I4__I4__SZARRAY_U1__I4__I4__I4__BYREF_I4,   // [9] W5500Socket.NativeReceive
     Library_cubley_interop_W5500Socket_NativeClose___STATIC__I4__I4,                                       // [10] W5500Socket.NativeClose
-    Library_cubley_interop_W5500Socket_NativeIsConnected___STATIC__BOOLEAN__I4,                            // [11]
-    Library_cubley_interop_W5500Socket_NativeGetPhyStatus___STATIC__U4,                                    // [12]
+    Library_cubley_interop_W5500Socket_NativeIsConnected___STATIC__BOOLEAN__I4,                            // [11] W5500Socket.NativeIsConnected
+    Library_cubley_interop_W5500Socket_NativeGetPhyStatus___STATIC__U4,                                    // [12] W5500Socket.NativeGetPhyStatus
     Library_cubley_interop_W5500Socket_NativeGetVersion___STATIC__U4,                                      // [13] W5500Socket.NativeGetVersion
     Library_cubley_interop_W5500Socket_NativeGetVersionPhyStatus___STATIC__U4,                             // [14] W5500Socket.NativeGetVersionPhyStatus
     Library_cubley_interop_W5500Socket_NativeSetPhyMode___STATIC__U4__I4,                                  // [15] W5500Socket.NativeSetPhyMode
@@ -93,7 +93,7 @@ static const CLR_RT_MethodHandler method_lookup[] =
 extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_Cubley_Interop =
 {
     "Cubley.Interop",
-    0x2F4C7DCD,  // nativeMethodsChecksum from Cubley.Interop.pe (computed by MetaDataProcessor)
+    0xC5EF91C9,  // nativeMethodsChecksum from Cubley.Interop.pe (computed by MetaDataProcessor)
     method_lookup,
     { 1, 0, 0, 0 }
 };

--- a/software/nanoFramework/nf-native/w5500_interop.cpp
+++ b/software/nanoFramework/nf-native/w5500_interop.cpp
@@ -535,6 +535,45 @@ static void w5500_apply_network_settings()
     w5500_write_buf(W5500_SIPR, W5500_BSB_COMMON, g_networkIp, 4);
 }
 
+static uint8_t w5500_probe_version_minimal(uint8_t *outPhyCfgr)
+{
+    // Presence-only probe: configure pins/SPI, read VERSIONR and PHYCFGR, and
+    // avoid socket allocation and full hardware init side effects.
+    palSetLineMode(PAL_LINE(GPIOB, 13U), PAL_MODE_ALTERNATE(5));
+    palSetLineMode(PAL_LINE(GPIOB, 14U), PAL_MODE_ALTERNATE(5));
+    palSetLineMode(PAL_LINE(GPIOB, 15U), PAL_MODE_ALTERNATE(5));
+    palSetLineMode(W5500_CS_LINE, PAL_MODE_OUTPUT_PUSHPULL);
+    w5500_cs_gpio_release();
+    palSetLineMode(W5500_RESET_LINE, PAL_MODE_OUTPUT_PUSHPULL);
+    palSetLine(W5500_RESET_LINE);
+    palSetLineMode(W5500_INT_LINE, PAL_MODE_INPUT_PULLUP);
+
+    w5500_spi_start();
+    w5500_spi_set_cr1((uint16_t)(SPI_CR1_BR_2 | SPI_CR1_BR_1 | SPI_CR1_BR_0));
+
+    uint8_t version = 0;
+    for (int i = 0; i < 3; i++)
+    {
+        version = w5500_read8(W5500_VERSIONR, W5500_BSB_COMMON);
+        if (version == 0x04)
+        {
+            break;
+        }
+        chThdSleepMilliseconds(1);
+    }
+
+    const uint8_t phycfgr = w5500_read8(W5500_PHYCFGR, W5500_BSB_COMMON);
+    w5500_spi_set_cr1(SPI_CR1_BR_1);
+
+    if (outPhyCfgr != NULL)
+    {
+        *outPhyCfgr = phycfgr;
+    }
+
+    set_w5500_last_native_error(0x56, version, phycfgr);
+    return version;
+}
+
 static w5500_socket_status_t w5500_hw_init()
 {
     set_w5500_last_native_error(0x40, 0x00, 0x00);
@@ -1256,8 +1295,9 @@ HRESULT Library_cubley_interop_W5500Socket_NativeGetVersion___STATIC__U4(CLR_RT_
 
     if (!g_initialized)
     {
-        stack.SetResult_U4(0);
-        set_w5500_last_native_error(0x52, (uint8_t)W5500_SOCKET_NOT_INITIALIZED, 0x00);
+        version = w5500_probe_version_minimal(&phycfgr);
+        stack.SetResult_U4((uint32_t)version);
+        set_w5500_bringup_status(5, version == 0x04 ? 1 : 14, version);
         NANOCLR_SET_AND_LEAVE(S_OK);
     }
 

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/InteropContractTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/InteropContractTests.cs
@@ -1,6 +1,7 @@
 using DiSEqC_Control.Native;
 using System.Reflection;
 using CubleyW5500 = Cubley.Interop.W5500Socket;
+using CubleyLnb = Cubley.Interop.LNBH26;
 
 namespace DiSEqC_Control.Tests;
 
@@ -127,23 +128,26 @@ public class LnbInteropContractTests
     [Fact]
     public void StatusEnumValues_AreStable()
     {
-        Assert.Equal(0, (int)LNB.Status.Ok);
-        Assert.Equal(1, (int)LNB.Status.InvalidParam);
-        Assert.Equal(2, (int)LNB.Status.NotInitialized);
+        Assert.Equal(0, (int)LNBH26.Status.Ok);
+        Assert.Equal(1, (int)LNBH26.Status.InvalidParam);
+        Assert.Equal(2, (int)LNBH26.Status.NotInitialized);
     }
 
     [Fact]
     public void DomainEnumValues_AreStable()
     {
-        Assert.Equal(0, (int)LNB.Voltage.V13);
-        Assert.Equal(1, (int)LNB.Voltage.V18);
-        Assert.Equal(0, (int)LNB.Polarization.Vertical);
-        Assert.Equal(1, (int)LNB.Polarization.Horizontal);
-        Assert.Equal(0, (int)LNB.Band.Low);
-        Assert.Equal(1, (int)LNB.Band.High);
+        Assert.Equal(0, (int)LNBH26.Voltage.V13);
+        Assert.Equal(1, (int)LNBH26.Voltage.V18);
+        Assert.Equal(0, (int)LNBH26.Polarization.Vertical);
+        Assert.Equal(1, (int)LNBH26.Polarization.Horizontal);
+        Assert.Equal(0, (int)LNBH26.Band.Low);
+        Assert.Equal(1, (int)LNBH26.Band.High);
     }
 
     [Theory]
+    [InlineData("NativeInit")]
+    [InlineData("NativeSetEnable")]
+    [InlineData("NativeReadStatus")]
     [InlineData("NativeSetVoltage")]
     [InlineData("NativeSetPolarization")]
     [InlineData("NativeSetTone")]
@@ -154,11 +158,18 @@ public class LnbInteropContractTests
     [InlineData("NativeGetBand")]
     public void InternalNativeMethods_HaveExternShape(string methodName)
     {
-        var method = typeof(LNB).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        var method = typeof(CubleyLnb).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
 
         Assert.NotNull(method);
-        Assert.True(method.IsPrivate);
+        Assert.True(method.IsPublic);
         Assert.True(method.IsStatic);
         Assert.Null(method.GetMethodBody());
+    }
+
+    [Fact]
+    public void ManagedLnbWrapper_PublicApi_IsPresent()
+    {
+        Assert.NotNull(typeof(LNBH26).GetMethod(nameof(LNBH26.SetVoltage), BindingFlags.Public | BindingFlags.Static));
+        Assert.NotNull(typeof(LNBH26).GetMethod(nameof(LNBH26.GetBand), BindingFlags.Public | BindingFlags.Static));
     }
 }

--- a/software/nanoFramework/toolchain/interop-checksum.sh
+++ b/software/nanoFramework/toolchain/interop-checksum.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 ASSEMBLY_INFO_PATH="$ROOT_DIR/Cubley.Interop/Properties/AssemblyInfo.cs"
 NATIVE_INTEROP_PATH="$ROOT_DIR/nf-native/cubley_interop.cpp"
-DEFAULT_PE_PATH="$ROOT_DIR/Cubley.Interop/bin/Release/Cubley.Interop.pe"
+DEFAULT_PE_PATH="$ROOT_DIR/build/DiSEqC_Control/Cubley.Interop.pe"
 ALLOWED_NATIVE_VERSION_FILE="$ASSEMBLY_INFO_PATH"
 
 MODE="check"

--- a/software/nanoFramework/toolchain/interop-guard.sh
+++ b/software/nanoFramework/toolchain/interop-guard.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CS_PATH="$ROOT_DIR/Cubley.Interop/CubleyInteropNative.cs"
+NATIVE_PATH="$ROOT_DIR/nf-native/cubley_interop.cpp"
+
+python3 - "$CS_PATH" "$NATIVE_PATH" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+cs_path = Path(sys.argv[1])
+native_path = Path(sys.argv[2])
+
+cs_text = cs_path.read_text(encoding="utf-8")
+native_text = native_path.read_text(encoding="utf-8")
+
+class_re = re.compile(r"^\s*public\s+static\s+class\s+([A-Za-z0-9_]+)")
+method_re = re.compile(r"^\s*(public|private)\s+static\s+(extern\s+)?[A-Za-z0-9_<>,\[\]\s]+\s+([A-Za-z0-9_]+)\s*\(")
+
+current_class = None
+pending_internal = False
+internalcall_methods = []
+non_extern_methods = []
+
+for line in cs_text.splitlines():
+    m_class = class_re.match(line)
+    if m_class:
+        current_class = m_class.group(1)
+
+    if "[MethodImpl(MethodImplOptions.InternalCall)]" in line:
+        pending_internal = True
+        continue
+
+    m_method = method_re.match(line)
+    if not m_method or current_class is None:
+        continue
+
+    is_extern = m_method.group(2) is not None
+    method_name = m_method.group(3)
+    fq_name = f"{current_class}.{method_name}"
+
+    if pending_internal:
+        if not is_extern:
+            print(f"ERROR: InternalCall method is not extern: {fq_name}")
+            sys.exit(1)
+        internalcall_methods.append(fq_name)
+    elif not is_extern:
+        non_extern_methods.append(fq_name)
+
+    pending_internal = False
+
+if non_extern_methods:
+    print("ERROR: Cubley.Interop must be native-only; managed method bodies found:")
+    for name in non_extern_methods:
+        print(f"  - {name}")
+    sys.exit(1)
+
+lookup_match = re.search(
+    r"static\s+const\s+CLR_RT_MethodHandler\s+method_lookup\[\]\s*=\s*\{(?P<body>.*?)\};",
+    native_text,
+    flags=re.S,
+)
+if not lookup_match:
+    print("ERROR: Unable to locate method_lookup[] in native file")
+    sys.exit(1)
+
+lookup_body = lookup_match.group("body")
+if re.search(r"^\s*NULL\s*,", lookup_body, flags=re.M):
+    print("ERROR: method_lookup[] contains NULL entries; Cubley.Interop should map only native methods.")
+    sys.exit(1)
+
+lookup_entries = []
+for line in lookup_body.splitlines():
+    m = re.search(r"//\s*\[(\d+)\]\s+([A-Za-z0-9_]+\.[A-Za-z0-9_]+)", line)
+    if not m:
+        continue
+    idx = int(m.group(1))
+    name = m.group(2)
+    lookup_entries.append((idx, name))
+
+if not lookup_entries:
+    print("ERROR: method_lookup[] comments with [index] Class.Method markers were not found.")
+    sys.exit(1)
+
+for expected_idx, (idx, _) in enumerate(lookup_entries):
+    if idx != expected_idx:
+        print(f"ERROR: method_lookup index drift: expected [{expected_idx}] but found [{idx}].")
+        sys.exit(1)
+
+lookup_methods = [name for _, name in lookup_entries]
+
+if internalcall_methods != lookup_methods:
+    print("ERROR: InternalCall method order drift between CubleyInteropNative.cs and native method_lookup[].")
+    max_len = max(len(internalcall_methods), len(lookup_methods))
+    for i in range(max_len):
+        managed = internalcall_methods[i] if i < len(internalcall_methods) else "<missing>"
+        native = lookup_methods[i] if i < len(lookup_methods) else "<missing>"
+        marker = "OK" if managed == native else "DIFF"
+        print(f"  [{i:02d}] managed={managed} | native={native}  <-- {marker}")
+    sys.exit(1)
+
+print("Interop guard PASS: native-only Cubley.Interop and aligned method order.")
+PYEOF


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to run managed compile and interop guard checks.
- Add an interop guard script to detect `Cubley.Interop` method-order drift and non-native method bodies.
- Enforce `Cubley.Interop` as a native-only InternalCall surface.
- Move LNB managed wrapper behavior into the `DiSEqC_Control.Native` layer.
- Align checksum tooling default PE path with the active build output.

## Validation
- `./toolchain/build-managed.sh compile --project DiSEqC_Control/DiSEqC_Control.nfproj`
- `./toolchain/interop-checksum.sh --check --pe build/DiSEqC_Control/Cubley.Interop.pe`
- `./toolchain/interop-guard.sh`
- Full native + managed rebuild and flash sequence executed locally.
