### PR TITLE
Enforce bring-up log evidence fields

### DIFF
--- a/.github/skills/bringup-log-entry/SKILL.md
+++ b/.github/skills/bringup-log-entry/SKILL.md
@@ -31,8 +31,8 @@ Append concise, factual test-session entries to the repository bring-up log usin
    - optional note
 2. Validate that conclusion is factual and non-speculative.
 3. Call the helper script with explicit flags:
-   - ./toolchain/bringup_log_append.sh --result ... --conclusion ...
-   - include --commands, --artifact, --breakpoints, and --note when available
+   - ./toolchain/bringup_log_append.sh --result ... --commands ... --artifact ... --conclusion ...
+   - include --breakpoints and --note when available
 4. Confirm the append succeeded and report the timestamped heading added.
 
 ## Output Format
@@ -49,4 +49,4 @@ Append concise, factual test-session entries to the repository bring-up log usin
 - Never rewrite or reorder prior log history.
 - Keep conclusions short and evidence-based.
 - Prefer one entry per coherent test run.
-- If required fields are missing, ask for only the minimum needed facts (result + conclusion).
+- If required fields are missing, ask for only the minimum needed facts (result, commands, artifact, and conclusion).

--- a/docs/debug/BRINGUP_TEST_LOG.md
+++ b/docs/debug/BRINGUP_TEST_LOG.md
@@ -59,10 +59,12 @@ For each run, append one short entry with:
 - Pass/fail result
 - One-line conclusion
 
+Each entry must include `Command(s)` and `Artifact` fields so the run can be replayed from the log. Use `Artifact: none` only when no artifact applies.
+
 ## Quick logging helper
 Use the helper to append timestamped entries consistently:
 
-- `./toolchain/bringup_log_append.sh --result PASS|FAIL|INFO --conclusion "one-line conclusion"`
+- `./toolchain/bringup_log_append.sh --result PASS|FAIL|INFO --commands "..." --artifact "..." --conclusion "one-line conclusion"`
 
 Recommended full form for debug sessions:
 

--- a/software/nanoFramework/README.md
+++ b/software/nanoFramework/README.md
@@ -105,9 +105,9 @@ To keep debugging history stable across long sessions and context compaction, ap
 
 Helper command:
 
-- `./toolchain/bringup_log_append.sh --result PASS|FAIL|INFO --conclusion "one-line conclusion"`
+- `./toolchain/bringup_log_append.sh --result PASS|FAIL|INFO --commands "..." --artifact "..." --conclusion "one-line conclusion"`
 
-Use `--help` for optional fields (`--commands`, `--artifact`, `--breakpoints`, `--note`).
+Use `--help` for optional fields (`--breakpoints`, `--note`, `--baseline`, `--logfile`).
 
 ## MQTT Transport Mode (Phase 3.5)
 

--- a/software/nanoFramework/toolchain/bringup_log_append.sh
+++ b/software/nanoFramework/toolchain/bringup_log_append.sh
@@ -27,8 +27,10 @@ Usage:
     [--logfile /path/to/BRINGUP_TEST_LOG.md]
 
 Required fields:
-  --commands   Command summary that reproduces the run conditions.
-  --artifact   Artifact used by the run, or "none" if no artifact applies.
+  --result      PASS, FAIL, or INFO.
+  --conclusion  One-line factual summary.
+  --commands    Command summary that reproduces the run conditions.
+  --artifact    Artifact used by the run, or "none" if no artifact applies.
 
   --baseline yes|no   Mark the entry as baseline (default: yes).
                       Use --baseline no for any run that deviates from the
@@ -46,6 +48,8 @@ Example:
 
   ./toolchain/bringup_log_append.sh \
     --result INFO \
+    --commands "nanoff --nanodevice --serialport /dev/ttyUSB0 --baud 115200 --devicedetails" \
+    --artifact "none" \
     --baseline no \
     --conclusion "Experimental cubley-uart run — non-baseline, W5500 bring-up only"
 EOF

--- a/software/nanoFramework/toolchain/bringup_log_append.sh
+++ b/software/nanoFramework/toolchain/bringup_log_append.sh
@@ -19,12 +19,16 @@ Usage:
   ./toolchain/bringup_log_append.sh \
     --result PASS|FAIL|INFO \
     --conclusion "one-line conclusion" \
-    [--commands "command(s) run"] \
-    [--artifact "artifact used"] \
+    --commands "command(s) run" \
+    --artifact "artifact used" \
     [--breakpoints "bp list"] \
     [--note "extra note"] \
     [--baseline yes|no] \
     [--logfile /path/to/BRINGUP_TEST_LOG.md]
+
+Required fields:
+  --commands   Command summary that reproduces the run conditions.
+  --artifact   Artifact used by the run, or "none" if no artifact applies.
 
   --baseline yes|no   Mark the entry as baseline (default: yes).
                       Use --baseline no for any run that deviates from the
@@ -93,8 +97,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$RESULT" || -z "$CONCLUSION" ]]; then
-  echo "Error: --result and --conclusion are required." >&2
+if [[ -z "$RESULT" || -z "$CONCLUSION" || -z "$COMMANDS" || -z "$ARTIFACT" ]]; then
+  echo "Error: --result, --conclusion, --commands, and --artifact are required." >&2
   usage
   exit 2
 fi
@@ -129,12 +133,8 @@ fi
   if [[ "$BASELINE" == "no" ]]; then
     echo "- Baseline: NO — deviates from Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)"
   fi
-  if [[ -n "$COMMANDS" ]]; then
-    echo "- Command(s): ${COMMANDS}"
-  fi
-  if [[ -n "$ARTIFACT" ]]; then
-    echo "- Artifact: ${ARTIFACT}"
-  fi
+  echo "- Command(s): ${COMMANDS}"
+  echo "- Artifact: ${ARTIFACT}"
   if [[ -n "$BREAKPOINTS" ]]; then
     echo "- Breakpoints: ${BREAKPOINTS}"
   fi


### PR DESCRIPTION
## Summary
- Require `--commands` and `--artifact` in the bring-up log helper so entries are replayable.
- Update the bring-up log guidance and skill instructions to match the stricter evidence format.
- Keep the log entry format aligned with Phase A evidence expectations.

## Validation
- `software/nanoFramework/toolchain/bringup_log_append.sh --result INFO --commands "test command" --artifact "test artifact" --conclusion "test conclusion" --logfile <temp log>`
- `software/nanoFramework/toolchain/bringup_log_append.sh --result INFO --conclusion "missing fields" --artifact "test artifact" --logfile <temp log>`
