### PR TITLE
Define Phase A exit gate

### DIFF
--- a/docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md
+++ b/docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md
@@ -469,7 +469,7 @@ Phase A may exit only when all of the following are true:
 4. The run history in [BRINGUP_TEST_LOG.md](./BRINGUP_TEST_LOG.md) contains the factual command, artifact, breakpoint, and conclusion evidence for the qualifying runs.
 5. The baseline used for the qualifying runs matches [PHASE_A_BASELINE.md](./PHASE_A_BASELINE.md) unless the run is explicitly marked non-baseline.
 
-The component definitions in the issue #23 minimum bring-up criteria comment are the source template for these checks: capability statement, test action(s), observable evidence, pass/fail rule, retries/failure classification, and deferred deeper validation.
+The component definitions in the Issue #23 “minimum bring-up criteria” comment (https://github.com/getpwnam/diseqc_cntrl/issues/23#issuecomment-4640616409) are the source template for these checks: capability statement, test action(s), observable evidence, pass/fail rule, retries/failure classification, and deferred deeper validation.
 
 ---
 

--- a/docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md
+++ b/docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md
@@ -459,6 +459,18 @@ SWD-probing under load are Phase D scope.  For word encoding reference see
 | 7 | DiSEqC transmit path | Oscilloscope shows ~22 kHz carrier burst with recognisable bit structure | 3 resets |
 | 8 | Diagnostics mailbox | All slots correct magic; boot-probe non-zero; stage order valid; sticky slots persist | 3 resets |
 
+## Phase A Exit Gate
+
+Phase A may exit only when all of the following are true:
+
+1. Every non-exempt component in the summary table above has a documented PASS result against its smoke check.
+2. Each PASS result satisfies the listed minimum iterations, including any per-component repeated-read or repeated-reset requirement.
+3. Any temporary exemption is documented with an owner, a rationale, the affected component, and an expiry condition.
+4. The run history in [BRINGUP_TEST_LOG.md](./BRINGUP_TEST_LOG.md) contains the factual command, artifact, breakpoint, and conclusion evidence for the qualifying runs.
+5. The baseline used for the qualifying runs matches [PHASE_A_BASELINE.md](./PHASE_A_BASELINE.md) unless the run is explicitly marked non-baseline.
+
+The component definitions in the issue #23 minimum bring-up criteria comment are the source template for these checks: capability statement, test action(s), observable evidence, pass/fail rule, retries/failure classification, and deferred deeper validation.
+
 ---
 
 ## References

--- a/docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md
+++ b/docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md
@@ -465,7 +465,7 @@ Phase A may exit only when all of the following are true:
 
 1. Every non-exempt component in the summary table above has a documented PASS result against its smoke check.
 2. Each PASS result satisfies the listed minimum iterations, including any per-component repeated-read or repeated-reset requirement.
-3. Any temporary exemption is documented with an owner, a rationale, the affected component, and an expiry condition.
+3. Any temporary exemption is documented in [BRINGUP_TEST_LOG.md](./BRINGUP_TEST_LOG.md) with an owner, a rationale, the affected component, and an expiry condition.
 4. The run history in [BRINGUP_TEST_LOG.md](./BRINGUP_TEST_LOG.md) contains the factual command, artifact, breakpoint, and conclusion evidence for the qualifying runs.
 5. The baseline used for the qualifying runs matches [PHASE_A_BASELINE.md](./PHASE_A_BASELINE.md) unless the run is explicitly marked non-baseline.
 

--- a/docs/debug/TESTING_GUIDE.md
+++ b/docs/debug/TESTING_GUIDE.md
@@ -10,7 +10,7 @@ defined in:
 
 > **[PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md](./PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md)**
 
-Phase A exit is also gated by the exit-gate section in that document.
+Phase A exit is also gated by the [Phase A Exit Gate](./PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md#phase-a-exit-gate) section in that document.
 
 ## Current Profile Notes
 

--- a/docs/debug/TESTING_GUIDE.md
+++ b/docs/debug/TESTING_GUIDE.md
@@ -10,6 +10,8 @@ defined in:
 
 > **[PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md](./PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md)**
 
+Phase A exit is also gated by the exit-gate section in that document.
+
 ## Current Profile Notes
 
 - The currently validated build profile has `System.Net` disabled.


### PR DESCRIPTION
## Summary
- Define a Phase A exit-gate section in the smoke-check doc.
- Tie the runbook to the exit gate so the acceptance criteria are visible from the bring-up flow.
- Reuse the issue #23 minimum bring-up criteria template as the source pattern for the component definitions.

## Validation
- `git diff -- docs/debug/PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md docs/debug/TESTING_GUIDE.md`
