### PR TITLE
Issue #26: record deterministic 20-cycle campaign and helper

### DIFF
--- a/docs/debug/BRINGUP_TEST_LOG.md
+++ b/docs/debug/BRINGUP_TEST_LOG.md
@@ -1153,3 +1153,30 @@ This file should be committed and checked on each build to prevent version drift
 - Artifact: DiSEqC_Control/bin/Release/DiSEqC_Control_bundle_20260526-235634.bin
 - Conclusion: Managed app is running and LNB detected in boot bitmap, but SMA output measured about 0.6V.
 - Note: User will continue LNB output debug tomorrow.
+
+### 2026-06-07 21:17:18 UTC [INFO] [NON-BASELINE]
+- Git rev: f3cc117
+- Baseline: NO — deviates from Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): st-info --probe; st-flash reset; st-flash write build/nanoBooter.bin 0x08000000; st-flash write build/nanoCLR.bin 0x08004000; nanoff --listports; ./toolchain/uart-preflight.sh --log-dir .debug/issue26_campaign_20260607T211620Z/cycle_01/uart-preflight --require-raw-bytes
+- Artifact: build/nanoBooter.bin; build/nanoCLR.bin; .debug/issue26_campaign_20260607T211620Z
+- Conclusion: Issue 26 campaign prep reached cycle 01 flash and reset, but UART transport is unavailable in this container so transport-health validation cannot proceed
+
+### 2026-06-07 21:26:54 UTC [FAIL] [NON-BASELINE]
+- Git rev: f3cc117
+- Baseline: NO — deviates from Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): ./toolchain/build-native.sh build --profile core-only; st-flash write build/nanoBooter.bin 0x08000000; st-flash write build/nanoCLR.bin 0x08004000; st-flash reset; nanoff --listports; nanoff --nanodevice --serialport /dev/ttyUSB0 --baud 115200 --listdevices; nanoff --nanodevice --serialport /dev/ttyUSB0 --baud 115200 --devicedetails
+- Artifact: build/nanoBooter.bin; build/nanoCLR.bin; /tmp/issue26_core_only_*.log
+- Conclusion: Core-only minimal native firmware still returns nanoff No devices found/E2001 on /dev/ttyUSB0, so transport failure is not caused by extra native probe/LED logic
+
+### 2026-06-07 21:36:28 UTC [INFO] [NON-BASELINE]
+- Git rev: f3cc117
+- Baseline: NO — deviates from Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): ./toolchain/build-native.sh build --profile core-only; ./toolchain/build-native.sh build --profile cubley-stable; manual st-flash write/reset sequence; nanoff --listports/listdevices/devicedetails; python serial open /dev/ttyUSB0; ./tests/swd_read_bringup_status.sh
+- Artifact: build/nanoBooter.bin; build/nanoCLR.bin; /tmp/issue26_core_only_*.log; /tmp/issue26_stable_*.log; /tmp/issue26_uart_hexdump.log; /tmp/issue26_swd_status.log
+- Conclusion: Both core-only and cubley-stable produce identical nanoff failure modes, while ST-Link remains stable and ttyUSB0 intermittently reports ENXIO/no COM availability, indicating host/container UART device-path instability rather than profile-specific native firmware behavior
+
+### 2026-06-07 22:09:55 UTC [PASS]
+- Git rev: f3cc117
+- Command(s): st-flash write build/nanoBooter.bin 0x08000000; st-flash write build/nanoCLR.bin 0x08004000; st-flash reset; sleep 2; nanoff --nanodevice --serialport /dev/ttyUSB0 --baud 115200 --listdevices; nanoff --nanodevice --serialport /dev/ttyUSB0 --baud 115200 --devicedetails (x20 cycles)
+- Artifact: build/nanoBooter.bin; build/nanoCLR.bin; .debug/issue26_campaign_20260607T215707Z
+- Conclusion: 20/20 flash-reset cycles PASS (0 failures) on cubley-stable profile; explicit st-flash reset before nanoff probe is required for deterministic transport health; per-cycle logs in .debug/issue26_campaign_20260607T215707Z

--- a/software/nanoFramework/README.md
+++ b/software/nanoFramework/README.md
@@ -109,6 +109,14 @@ Helper command:
 
 Use `--help` for optional fields (`--breakpoints`, `--note`, `--baseline`, `--logfile`).
 
+### Deterministic Cycle Campaign Helper
+
+For Phase A issue #26 style repeatability runs, use:
+
+- `./toolchain/run-deterministic-cycles.sh --cycles 20 --serial /dev/ttyUSB0 --baud 115200 --settle-ms 2000`
+
+The helper performs booter flash, CLR flash, explicit `st-flash reset`, then `nanoff --listdevices` and `--devicedetails` per cycle, writing per-cycle logs under `.debug/`.
+
 ## MQTT Transport Mode (Phase 3.5)
 
 Runtime config key:

--- a/software/nanoFramework/toolchain/run-deterministic-cycles.sh
+++ b/software/nanoFramework/toolchain/run-deterministic-cycles.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./toolchain/run-deterministic-cycles.sh [options]
+
+Runs repeated flash/reset cycles and probes UART wire-protocol health.
+
+Options:
+  --cycles <n>            Number of cycles (default: 20)
+  --serial <port>         Serial device (default: /dev/ttyUSB0)
+  --baud <rate>           Serial baud rate (default: 115200)
+  --settle-ms <ms>        Delay after reset before nanoff probes (default: 2000)
+  --booter <path>         nanoBooter image (default: build/nanoBooter.bin)
+  --clr <path>            nanoCLR image (default: build/nanoCLR.bin)
+  --bootaddr <hex>        nanoBooter flash address (default: 0x08000000)
+  --clraddr <hex>         nanoCLR flash address (default: 0x08004000)
+  --log-root <dir>        Output log root (default: .debug/issue26_campaign_<utc>)
+  --stop-on-fail          Stop immediately on first failed cycle
+  -h, --help              Show help
+
+Exit codes:
+  0 if all cycles pass; 1 otherwise.
+EOF
+}
+
+CYCLES=20
+SERIAL_PORT="/dev/ttyUSB0"
+BAUD=115200
+SETTLE_MS=2000
+BOOTER_IMG="build/nanoBooter.bin"
+CLR_IMG="build/nanoCLR.bin"
+BOOT_ADDR="0x08000000"
+CLR_ADDR="0x08004000"
+LOG_ROOT=""
+STOP_ON_FAIL=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cycles)
+      CYCLES="${2:-}"
+      shift 2
+      ;;
+    --serial)
+      SERIAL_PORT="${2:-}"
+      shift 2
+      ;;
+    --baud)
+      BAUD="${2:-}"
+      shift 2
+      ;;
+    --settle-ms)
+      SETTLE_MS="${2:-}"
+      shift 2
+      ;;
+    --booter)
+      BOOTER_IMG="${2:-}"
+      shift 2
+      ;;
+    --clr)
+      CLR_IMG="${2:-}"
+      shift 2
+      ;;
+    --bootaddr)
+      BOOT_ADDR="${2:-}"
+      shift 2
+      ;;
+    --clraddr)
+      CLR_ADDR="${2:-}"
+      shift 2
+      ;;
+    --log-root)
+      LOG_ROOT="${2:-}"
+      shift 2
+      ;;
+    --stop-on-fail)
+      STOP_ON_FAIL=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$CYCLES" =~ ^[0-9]+$ ]] || [[ "$CYCLES" -le 0 ]]; then
+  echo "Error: --cycles must be a positive integer." >&2
+  exit 2
+fi
+
+if ! [[ "$BAUD" =~ ^[0-9]+$ ]] || [[ "$BAUD" -le 0 ]]; then
+  echo "Error: --baud must be a positive integer." >&2
+  exit 2
+fi
+
+if ! [[ "$SETTLE_MS" =~ ^[0-9]+$ ]]; then
+  echo "Error: --settle-ms must be a non-negative integer." >&2
+  exit 2
+fi
+
+if [[ -z "$LOG_ROOT" ]]; then
+  LOG_ROOT=".debug/issue26_campaign_$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+
+mkdir -p "$LOG_ROOT"
+SUMMARY_FILE="$LOG_ROOT/summary.log"
+FAIL_COUNT=0
+
+log() {
+  printf '%s\n' "$*" | tee -a "$SUMMARY_FILE"
+}
+
+if [[ ! -f "$BOOTER_IMG" ]]; then
+  echo "Error: booter image not found: $BOOTER_IMG" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CLR_IMG" ]]; then
+  echo "Error: CLR image not found: $CLR_IMG" >&2
+  exit 1
+fi
+
+GIT_REV="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+log "campaign_root=$LOG_ROOT git_rev=$GIT_REV"
+log "serial_port=$SERIAL_PORT baud=$BAUD settle_ms=$SETTLE_MS cycles=$CYCLES"
+log "booter=$BOOTER_IMG bootaddr=$BOOT_ADDR"
+log "clr=$CLR_IMG clraddr=$CLR_ADDR"
+
+for i in $(seq 1 "$CYCLES"); do
+  CYCLE_ID=$(printf '%02d' "$i")
+  CYCLE_DIR="$LOG_ROOT/cycle_$CYCLE_ID"
+  mkdir -p "$CYCLE_DIR"
+
+  log "--- cycle $CYCLE_ID ---"
+
+  if st-flash write "$BOOTER_IMG" "$BOOT_ADDR" >"$CYCLE_DIR/st_flash_booter.log" 2>&1; then
+    log "cycle $CYCLE_ID: booter_flash=OK"
+  else
+    log "cycle $CYCLE_ID: booter_flash=FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+    continue
+  fi
+
+  if st-flash write "$CLR_IMG" "$CLR_ADDR" >"$CYCLE_DIR/st_flash_clr.log" 2>&1; then
+    log "cycle $CYCLE_ID: clr_flash=OK"
+  else
+    log "cycle $CYCLE_ID: clr_flash=FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+    continue
+  fi
+
+  if st-flash reset >"$CYCLE_DIR/st_flash_reset.log" 2>&1; then
+    log "cycle $CYCLE_ID: reset=OK"
+  else
+    log "cycle $CYCLE_ID: reset=FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+    continue
+  fi
+
+  if [[ "$SETTLE_MS" -gt 0 ]]; then
+    sleep "$(awk "BEGIN { printf \"%.3f\", $SETTLE_MS/1000 }")"
+  fi
+
+  nanoff --listports >"$CYCLE_DIR/nanoff_listports.log" 2>&1 || true
+  nanoff --nanodevice --serialport "$SERIAL_PORT" --baud "$BAUD" --listdevices >"$CYCLE_DIR/nanoff_listdevices.log" 2>&1
+  LD_RC=$?
+  nanoff --nanodevice --serialport "$SERIAL_PORT" --baud "$BAUD" --devicedetails >"$CYCLE_DIR/nanoff_devicedetails.log" 2>&1
+  DD_RC=$?
+
+  if [[ "$LD_RC" -eq 0 && "$DD_RC" -eq 0 ]]; then
+    log "cycle $CYCLE_ID: listdevices_rc=$LD_RC devicedetails_rc=$DD_RC result=PASS"
+  else
+    log "cycle $CYCLE_ID: listdevices_rc=$LD_RC devicedetails_rc=$DD_RC result=FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+  fi
+done
+
+log "CAMPAIGN COMPLETE: fails=$FAIL_COUNT/$CYCLES"
+printf 'CAMPAIGN_ROOT=%s\n' "$LOG_ROOT"
+
+if [[ "$FAIL_COUNT" -eq 0 ]]; then
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- Record issue #26 20-cycle deterministic flash-reset campaign evidence in bring-up log.
- Add reusable helper script `toolchain/run-deterministic-cycles.sh` for repeatable campaigns.
- Document helper usage in `software/nanoFramework/README.md`.

## Validation
- `./toolchain/run-deterministic-cycles.sh --cycles 20 --serial /dev/ttyUSB0 --baud 115200 --settle-ms 2000`
- Campaign artifact: `.debug/issue26_campaign_20260607T215707Z`
- Result: `CAMPAIGN COMPLETE: fails=0/20`
