### PR TITLE
[Phase B] Interop governance, guards, and drift tests

### DIFF
--- a/docs/debug/TESTING_GUIDE.md
+++ b/docs/debug/TESTING_GUIDE.md
@@ -19,6 +19,9 @@ The Phase A freeze/handoff decision record is captured in [PHASE_A_EXIT_DECISION
 
 - The currently validated build profile has `System.Net` disabled.
 - MQTT/network test phases in this guide are optional unless networking is re-enabled in the build profile.
+- Interop slot/checksum governance for Cubley native calls is defined in [INTEROP_CONTRACT_V1.md](../software/INTEROP_CONTRACT_V1.md).
+- Interop compatibility and review rules are defined in [INTEROP_VERSIONING_POLICY.md](../software/INTEROP_VERSIONING_POLICY.md).
+- Intentional drift regression check: run `./software/nanoFramework/toolchain/interop-negative-drift-test.sh` and require `PASS`.
 
 ## Prerequisites
 

--- a/docs/software/ARCHITECTURE.md
+++ b/docs/software/ARCHITECTURE.md
@@ -88,6 +88,8 @@ The first three are upstream bugs/limitations; the last two are board-specific d
 
 - `../README.md`
 - `../debug/TESTING_GUIDE.md`
+- `INTEROP_CONTRACT_V1.md`
+- `INTEROP_VERSIONING_POLICY.md`
 - `MQTT_API.md`
 - `CONFIGURATION.md`
 - `../debug/LNB_I2C_TESTING.md`

--- a/docs/software/INTEROP_CONTRACT_V1.md
+++ b/docs/software/INTEROP_CONTRACT_V1.md
@@ -1,0 +1,86 @@
+# Interop Contract v1 (Cubley.Interop)
+
+## Purpose
+
+Define the immutable v1 InternalCall slot map and compatibility policy for `Cubley.Interop`.
+This document is the source of truth for method slot governance in v1.x.
+
+## Scope
+
+- Managed assembly: `Cubley.Interop`
+- Managed declarations: `software/nanoFramework/Cubley.Interop/CubleyInteropNative.cs`
+- Native table: `software/nanoFramework/nf-native/cubley_interop.cpp` (`method_lookup`)
+- Runtime export: `g_CLR_AssemblyNative_Cubley_Interop`
+
+## Identity
+
+- Assembly name: `Cubley.Interop`
+- Native methods checksum (v1 baseline): `0xC5EF91C9`
+- Native assembly version tuple: `{ 1, 0, 0, 0 }`
+
+## Slot Policy (v1.x)
+
+- Slots `0..33` are immutable in v1.x.
+- Each slot is permanently owned by one fully-qualified API method and cannot be repurposed.
+- Existing slots cannot be reordered, deleted, or reused.
+- New APIs in v1.x are append-only and must be added at the end of `method_lookup`.
+- Any signature change that would alter metadata ordering or checksum is a breaking change and is not allowed in v1.x.
+
+## Canonical Slot Map (v1)
+
+| Slot | API | Managed Signature |
+|---:|---|---|
+| 0 | `BringupStatus.NativeSet` | `void NativeSet(uint statusWord)` |
+| 1 | `BringupStatus.NativeGet` | `uint NativeGet()` |
+| 2 | `BringupStatus.NativeGetLastNativeError` | `uint NativeGetLastNativeError()` |
+| 3 | `DiagnosticsMailbox.NativeTryLatchBootProbe` | `bool NativeTryLatchBootProbe(uint statusWord)` |
+| 4 | `DiagnosticsMailbox.NativeGetBootProbe` | `uint NativeGetBootProbe()` |
+| 5 | `W5500Socket.NativeOpen` | `int NativeOpen(out int socketHandle)` |
+| 6 | `W5500Socket.NativeConfigureNetwork` | `int NativeConfigureNetwork(string localIp, string subnetMask, string gateway, string macAddress)` |
+| 7 | `W5500Socket.NativeConnect` | `int NativeConnect(int socketHandle, string host, int port, int timeoutMs)` |
+| 8 | `W5500Socket.NativeSend` | `int NativeSend(int socketHandle, byte[] buffer, int offset, int count, out int bytesSent)` |
+| 9 | `W5500Socket.NativeReceive` | `int NativeReceive(int socketHandle, byte[] buffer, int offset, int count, int timeoutMs, out int bytesRead)` |
+| 10 | `W5500Socket.NativeClose` | `int NativeClose(int socketHandle)` |
+| 11 | `W5500Socket.NativeIsConnected` | `bool NativeIsConnected(int socketHandle)` |
+| 12 | `W5500Socket.NativeGetPhyStatus` | `uint NativeGetPhyStatus()` |
+| 13 | `W5500Socket.NativeGetVersion` | `uint NativeGetVersion()` |
+| 14 | `W5500Socket.NativeGetVersionPhyStatus` | `uint NativeGetVersionPhyStatus()` |
+| 15 | `W5500Socket.NativeSetPhyMode` | `uint NativeSetPhyMode(int modeCode)` |
+| 16 | `LNBH26.NativeInit` | `int NativeInit()` |
+| 17 | `LNBH26.NativeSetEnable` | `int NativeSetEnable(bool enable)` |
+| 18 | `LNBH26.NativeReadStatus` | `int NativeReadStatus(out int statusRegister)` |
+| 19 | `LNBH26.NativeSetVoltage` | `int NativeSetVoltage(int voltage)` |
+| 20 | `LNBH26.NativeSetPolarization` | `int NativeSetPolarization(int polarization)` |
+| 21 | `LNBH26.NativeSetTone` | `int NativeSetTone(bool enable)` |
+| 22 | `LNBH26.NativeSetBand` | `int NativeSetBand(int band)` |
+| 23 | `LNBH26.NativeGetVoltage` | `int NativeGetVoltage()` |
+| 24 | `LNBH26.NativeGetTone` | `bool NativeGetTone()` |
+| 25 | `LNBH26.NativeGetPolarization` | `int NativeGetPolarization()` |
+| 26 | `LNBH26.NativeGetBand` | `int NativeGetBand()` |
+| 27 | `StatusLed.NativeInit` | `void NativeInit()` |
+| 28 | `StatusLed.NativeSetHigh` | `void NativeSetHigh()` |
+| 29 | `StatusLed.NativeSetLow` | `void NativeSetLow()` |
+| 30 | `StatusLed.NativePulse` | `void NativePulse(int count, int pulseMs)` |
+| 31 | `UsbCdcConsole.NativeIsEnabled` | `bool NativeIsEnabled()` |
+| 32 | `UsbCdcConsole.NativeReadByte` | `int NativeReadByte(int timeoutMs)` |
+| 33 | `UsbCdcConsole.NativeWrite` | `int NativeWrite(string text)` |
+
+## Ownership Rules
+
+- `Cubley.Interop` maintainers own managed declaration order and signature stability.
+- `nf-native` maintainers own native symbol implementation and one-to-one table alignment.
+- Any change touching `CubleyInteropNative.cs` or `method_lookup` requires explicit interop review and contract check.
+
+## Update Protocol
+
+1. Propose change and classify it as compatible append or breaking.
+2. Run static slot audit: managed declaration order vs native `method_lookup` order.
+3. Recompute and verify native methods checksum from build output.
+4. Update this document only after code change is validated.
+5. For v1.x, append new rows at the end only. Do not modify rows `0..33`.
+
+## Verification Pointers
+
+- Validate managed declarations in `software/nanoFramework/Cubley.Interop/CubleyInteropNative.cs`.
+- Validate native table order in `software/nanoFramework/nf-native/cubley_interop.cpp`.
+- Validate runtime export checksum/version in `g_CLR_AssemblyNative_Cubley_Interop`.

--- a/docs/software/INTEROP_VERSIONING_POLICY.md
+++ b/docs/software/INTEROP_VERSIONING_POLICY.md
@@ -1,0 +1,49 @@
+# Interop Versioning Policy (v1.x)
+
+## Purpose
+
+Define compatibility and review rules for `Cubley.Interop` in the v1 major line.
+
+## Policy Scope
+
+- Managed declarations in `software/nanoFramework/Cubley.Interop/CubleyInteropNative.cs`
+- Native lookup/export in `software/nanoFramework/nf-native/cubley_interop.cpp`
+- Build guard scripts in `software/nanoFramework/toolchain/interop-guard.sh` and `software/nanoFramework/toolchain/interop-checksum.sh`
+
+## Compatibility Rules (v1.x)
+
+- Existing v1 slots are immutable and cannot be changed, removed, repurposed, or reordered.
+- Non-append edits to existing slots are breaking and prohibited in v1.x.
+- New methods are allowed only as append-only entries at the tail of the table.
+- `AssemblyNativeVersion` checksum and native export checksum must remain aligned.
+
+## What Is Compatible
+
+- Adding a new InternalCall as a new trailing slot, with matching managed/native declarations.
+- Non-interop internal implementation changes that do not change method ordering/signatures.
+
+## What Is Breaking
+
+- Reordering methods in `CubleyInteropNative.cs`.
+- Inserting a method in the middle of existing slots.
+- Deleting or renaming existing InternalCall methods.
+- Changing signatures in a way that changes metadata order/checksum without coordinated major-version policy.
+
+## Enforcement
+
+- `interop-guard.sh` enforces managed/native slot alignment and immutable v1 baseline prefix.
+- `interop-checksum.sh` enforces checksum alignment between managed metadata and native export.
+- `build-managed.sh` and `build-native.sh` run these checks as hard preflight gates.
+
+## Review Requirements
+
+Every interop change PR must include:
+
+1. Slot-impact statement (`no slot change` or `append-only slot addition`).
+2. Guard output showing PASS from both scripts.
+3. Contract update in `INTEROP_CONTRACT_V1.md` if any append occurred.
+
+## Versioning Notes
+
+- v1.x is append-only.
+- Any intentional non-append change requires a future major policy decision and a new contract/version line.

--- a/software/nanoFramework/README.md
+++ b/software/nanoFramework/README.md
@@ -14,6 +14,13 @@ Use the debug bring-up guides as the canonical starting path:
 
 This project has two independent build components. Run them separately.
 
+Interop governance for these build paths:
+
+- Contract map: `../../docs/software/INTEROP_CONTRACT_V1.md`
+- Versioning policy: `../../docs/software/INTEROP_VERSIONING_POLICY.md`
+- Enforced guards: `./toolchain/interop-guard.sh`, `./toolchain/interop-checksum.sh`
+- Negative drift fixture test: `./toolchain/interop-negative-drift-test.sh`
+
 ### 1) Managed Application Build (C# project)
 
 Builds the managed application in `DiSEqC_Control/` and validates C# compile health.

--- a/software/nanoFramework/docs/README.md
+++ b/software/nanoFramework/docs/README.md
@@ -28,6 +28,8 @@ Top-level docs taxonomy used by this repo:
 ## Reference
 
 - `../../../docs/software/ARCHITECTURE.md`
+- `../../../docs/software/INTEROP_CONTRACT_V1.md`
+- `../../../docs/software/INTEROP_VERSIONING_POLICY.md`
 - `../../../docs/software/MQTT_API.md`
 - `../../../docs/software/CONFIGURATION.md`
 - `../../../docs/software/TODO.md` (includes stable firmware + interop program phase tracker)

--- a/software/nanoFramework/toolchain/build-managed.sh
+++ b/software/nanoFramework/toolchain/build-managed.sh
@@ -7,6 +7,7 @@ PROJECT="${PROJECT:-}"
 SOLUTION="${SOLUTION:-}"
 PACKAGES_DIR="$ROOT_DIR/packages"
 CHECKSUM_TOOL="$SCRIPT_DIR/interop-checksum.sh"
+INTEROP_GUARD_TOOL="$SCRIPT_DIR/interop-guard.sh"
 
 DEFAULT_NANO_PS_PATH=""
 NANO_EXT_ROOT="${HOME:-/home/vscode}/.vscode-server/extensions"
@@ -472,11 +473,20 @@ if [[ -z "$NANO_PS_PATH" || ! -d "$NANO_PS_PATH" ]]; then
   exit 2
 fi
 
+if [[ -x "$INTEROP_GUARD_TOOL" ]]; then
+  echo "[preflight] Validating interop slot order and append-only baseline"
+  "$INTEROP_GUARD_TOOL"
+else
+  echo "[error] Interop guard tool not found or not executable: $INTEROP_GUARD_TOOL" >&2
+  exit 1
+fi
+
 if [[ -x "$CHECKSUM_TOOL" ]]; then
   echo "[preflight] Validating interop checksum and AssemblyNativeVersion scope"
   "$CHECKSUM_TOOL" --check
 else
-  echo "[warn] Interop checksum tool not found or not executable: $CHECKSUM_TOOL" >&2
+  echo "[error] Interop checksum tool not found or not executable: $CHECKSUM_TOOL" >&2
+  exit 1
 fi
 
 if [[ -z "$NF_MDP_MSBUILDTASK_PATH_EFFECTIVE" ]]; then
@@ -551,8 +561,9 @@ else
 
   if [[ -f "$CUBLEY_INTEROP_PE" && -x "$CHECKSUM_TOOL" ]]; then
     if ! "$CHECKSUM_TOOL" --check --pe "$CUBLEY_INTEROP_PE"; then
-      echo "[warn] Cubley.Interop checksum mismatch; continuing bundle creation." >&2
-      echo "[warn] To realign, run: $CHECKSUM_TOOL --fix --pe $CUBLEY_INTEROP_PE" >&2
+      echo "[error] Cubley.Interop checksum mismatch; refusing to continue." >&2
+      echo "[error] To realign, run: $CHECKSUM_TOOL --fix --pe $CUBLEY_INTEROP_PE" >&2
+      exit 1
     fi
   fi
 

--- a/software/nanoFramework/toolchain/build-native.sh
+++ b/software/nanoFramework/toolchain/build-native.sh
@@ -142,11 +142,21 @@ echo "========================================"
 # Preflight: fail fast if managed/native interop checksum metadata drifts.
 # This catches InternalCall binding breakage before entering CMake/build work.
 CHECKSUM_TOOL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/interop-checksum.sh"
+INTEROP_GUARD_TOOL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/interop-guard.sh"
+if [ "$MODE" = "build" ] && [ -x "$INTEROP_GUARD_TOOL" ]; then
+    echo "Running interop slot guard preflight..."
+    "$INTEROP_GUARD_TOOL"
+elif [ "$MODE" = "build" ]; then
+    echo "Error: interop slot guard tool not found or not executable: $INTEROP_GUARD_TOOL"
+    exit 1
+fi
+
 if [ "$MODE" = "build" ] && [ -x "$CHECKSUM_TOOL" ]; then
     echo "Running interop checksum preflight..."
     "$CHECKSUM_TOOL" --check
 elif [ "$MODE" = "build" ]; then
-    echo "Warning: checksum preflight tool not found or not executable: $CHECKSUM_TOOL"
+    echo "Error: checksum preflight tool not found or not executable: $CHECKSUM_TOOL"
+    exit 1
 fi
 
 # Colors

--- a/software/nanoFramework/toolchain/interop-guard.sh
+++ b/software/nanoFramework/toolchain/interop-guard.sh
@@ -7,6 +7,49 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CS_PATH="$ROOT_DIR/Cubley.Interop/CubleyInteropNative.cs"
 NATIVE_PATH="$ROOT_DIR/nf-native/cubley_interop.cpp"
 
+usage() {
+    cat <<'EOF'
+Usage:
+    ./toolchain/interop-guard.sh [--cs /path/to/CubleyInteropNative.cs] [--native /path/to/cubley_interop.cpp]
+
+Defaults:
+    --cs      software/nanoFramework/Cubley.Interop/CubleyInteropNative.cs
+    --native  software/nanoFramework/nf-native/cubley_interop.cpp
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cs)
+            CS_PATH="${2:-}"
+            shift 2
+            ;;
+        --native)
+            NATIVE_PATH="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f "$CS_PATH" ]]; then
+    echo "Missing file: $CS_PATH" >&2
+    exit 1
+fi
+
+if [[ ! -f "$NATIVE_PATH" ]]; then
+    echo "Missing file: $NATIVE_PATH" >&2
+    exit 1
+fi
+
 python3 - "$CS_PATH" "$NATIVE_PATH" <<'PYEOF'
 import re
 import sys
@@ -25,6 +68,44 @@ current_class = None
 pending_internal = False
 internalcall_methods = []
 non_extern_methods = []
+
+# v1 baseline slots are immutable in v1.x. New methods may only append.
+V1_BASELINE = [
+    "BringupStatus.NativeSet",
+    "BringupStatus.NativeGet",
+    "BringupStatus.NativeGetLastNativeError",
+    "DiagnosticsMailbox.NativeTryLatchBootProbe",
+    "DiagnosticsMailbox.NativeGetBootProbe",
+    "W5500Socket.NativeOpen",
+    "W5500Socket.NativeConfigureNetwork",
+    "W5500Socket.NativeConnect",
+    "W5500Socket.NativeSend",
+    "W5500Socket.NativeReceive",
+    "W5500Socket.NativeClose",
+    "W5500Socket.NativeIsConnected",
+    "W5500Socket.NativeGetPhyStatus",
+    "W5500Socket.NativeGetVersion",
+    "W5500Socket.NativeGetVersionPhyStatus",
+    "W5500Socket.NativeSetPhyMode",
+    "LNBH26.NativeInit",
+    "LNBH26.NativeSetEnable",
+    "LNBH26.NativeReadStatus",
+    "LNBH26.NativeSetVoltage",
+    "LNBH26.NativeSetPolarization",
+    "LNBH26.NativeSetTone",
+    "LNBH26.NativeSetBand",
+    "LNBH26.NativeGetVoltage",
+    "LNBH26.NativeGetTone",
+    "LNBH26.NativeGetPolarization",
+    "LNBH26.NativeGetBand",
+    "StatusLed.NativeInit",
+    "StatusLed.NativeSetHigh",
+    "StatusLed.NativeSetLow",
+    "StatusLed.NativePulse",
+    "UsbCdcConsole.NativeIsEnabled",
+    "UsbCdcConsole.NativeReadByte",
+    "UsbCdcConsole.NativeWrite",
+]
 
 for line in cs_text.splitlines():
     m_class = class_re.match(line)
@@ -93,6 +174,28 @@ for expected_idx, (idx, _) in enumerate(lookup_entries):
 
 lookup_methods = [name for _, name in lookup_entries]
 
+if len(lookup_methods) < len(V1_BASELINE):
+    print(
+        "ERROR: method_lookup[] has fewer entries than the v1 baseline; "
+        "v1 slots cannot be removed."
+    )
+    print(f"  baseline slots: {len(V1_BASELINE)}")
+    print(f"  current slots:  {len(lookup_methods)}")
+    sys.exit(1)
+
+prefix_drift = []
+for i, expected in enumerate(V1_BASELINE):
+    actual = lookup_methods[i]
+    if actual != expected:
+        prefix_drift.append((i, expected, actual))
+
+if prefix_drift:
+    print("ERROR: Non-append slot drift detected in immutable v1 baseline.")
+    for idx, expected, actual in prefix_drift:
+        print(f"  [{idx:02d}] expected={expected} | actual={actual}")
+    print("Only append-only additions are allowed after slot 33 for v1.x.")
+    sys.exit(1)
+
 if internalcall_methods != lookup_methods:
     print("ERROR: InternalCall method order drift between CubleyInteropNative.cs and native method_lookup[].")
     max_len = max(len(internalcall_methods), len(lookup_methods))
@@ -103,5 +206,9 @@ if internalcall_methods != lookup_methods:
         print(f"  [{i:02d}] managed={managed} | native={native}  <-- {marker}")
     sys.exit(1)
 
-print("Interop guard PASS: native-only Cubley.Interop and aligned method order.")
+appended = len(lookup_methods) - len(V1_BASELINE)
+print(
+    "Interop guard PASS: native-only Cubley.Interop, aligned method order, "
+    f"and immutable v1 baseline preserved (appended slots: {appended})."
+)
 PYEOF

--- a/software/nanoFramework/toolchain/interop-guard.sh
+++ b/software/nanoFramework/toolchain/interop-guard.sh
@@ -193,7 +193,11 @@ if prefix_drift:
     print("ERROR: Non-append slot drift detected in immutable v1 baseline.")
     for idx, expected, actual in prefix_drift:
         print(f"  [{idx:02d}] expected={expected} | actual={actual}")
-    print("Only append-only additions are allowed after slot 33 for v1.x.")
+    last_baseline_slot = len(V1_BASELINE) - 1
+    print(
+        "Only append-only additions are allowed after "
+        f"slot {last_baseline_slot} for v1.x."
+    )
     sys.exit(1)
 
 if internalcall_methods != lookup_methods:

--- a/software/nanoFramework/toolchain/interop-negative-drift-test.sh
+++ b/software/nanoFramework/toolchain/interop-negative-drift-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GUARD_TOOL="$SCRIPT_DIR/interop-guard.sh"
+SOURCE_CS="$ROOT_DIR/Cubley.Interop/CubleyInteropNative.cs"
+SOURCE_NATIVE="$ROOT_DIR/nf-native/cubley_interop.cpp"
+
+if [[ ! -x "$GUARD_TOOL" ]]; then
+  echo "Missing or non-executable guard tool: $GUARD_TOOL" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d /tmp/interop-drift-fixture-XXXXXX)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+FIXTURE_CS="$TMP_DIR/CubleyInteropNative.cs"
+FIXTURE_NATIVE="$TMP_DIR/cubley_interop.cpp"
+
+cp "$SOURCE_CS" "$FIXTURE_CS"
+cp "$SOURCE_NATIVE" "$FIXTURE_NATIVE"
+
+python3 - "$FIXTURE_NATIVE" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+
+pattern = re.compile(r"(static\s+const\s+CLR_RT_MethodHandler\s+method_lookup\[\]\s*=\s*\{)(.*?)(\n\};)", re.S)
+match = pattern.search(text)
+if not match:
+    raise SystemExit("Unable to locate method_lookup[] block for fixture mutation")
+
+body = match.group(2)
+lines = body.splitlines()
+
+entry_indices = [i for i, line in enumerate(lines) if "// [" in line and "." in line]
+if len(entry_indices) < 2:
+    raise SystemExit("Not enough method_lookup entries for fixture mutation")
+
+first = entry_indices[0]
+second = entry_indices[1]
+lines[first], lines[second] = lines[second], lines[first]
+
+mutated = text[:match.start(2)] + "\n".join(lines) + text[match.end(2):]
+path.write_text(mutated, encoding="utf-8")
+PYEOF
+
+set +e
+guard_output="$($GUARD_TOOL --cs "$FIXTURE_CS" --native "$FIXTURE_NATIVE" 2>&1)"
+guard_rc=$?
+set -e
+
+if [[ $guard_rc -eq 0 ]]; then
+  echo "FAIL: guard unexpectedly passed intentional non-append drift fixture." >&2
+  exit 1
+fi
+
+if ! grep -Eq "Non-append slot drift detected|method_lookup index drift|InternalCall method order drift" <<< "$guard_output"; then
+  echo "FAIL: guard failed for fixture but did not report expected drift diagnostics." >&2
+  echo "$guard_output" >&2
+  exit 1
+fi
+
+echo "PASS: intentional non-append drift fixture was detected and blocked."

--- a/software/nanoFramework/toolchain/interop-negative-drift-test.sh
+++ b/software/nanoFramework/toolchain/interop-negative-drift-test.sh
@@ -41,13 +41,26 @@ if not match:
 body = match.group(2)
 lines = body.splitlines()
 
-entry_indices = [i for i, line in enumerate(lines) if "// [" in line and "." in line]
+entry_regex = re.compile(r"(//\s*\[(\d+)\]\s+)([A-Za-z0-9_]+\.[A-Za-z0-9_]+)")
+entry_indices = [i for i, line in enumerate(lines) if entry_regex.search(line)]
 if len(entry_indices) < 2:
     raise SystemExit("Not enough method_lookup entries for fixture mutation")
 
-first = entry_indices[0]
-second = entry_indices[1]
-lines[first], lines[second] = lines[second], lines[first]
+first_idx = entry_indices[0]
+second_idx = entry_indices[1]
+
+first_match = entry_regex.search(lines[first_idx])
+second_match = entry_regex.search(lines[second_idx])
+if not first_match or not second_match:
+  raise SystemExit("Failed to parse method_lookup comment markers for fixture mutation")
+
+first_name = first_match.group(3)
+second_name = second_match.group(3)
+
+# Intentionally swap only API names in comments while keeping slot indices/line order.
+# This ensures the guard reaches immutable v1 baseline drift detection.
+lines[first_idx] = lines[first_idx].replace(first_name, second_name, 1)
+lines[second_idx] = lines[second_idx].replace(second_name, first_name, 1)
 
 mutated = text[:match.start(2)] + "\n".join(lines) + text[match.end(2):]
 path.write_text(mutated, encoding="utf-8")
@@ -63,8 +76,8 @@ if [[ $guard_rc -eq 0 ]]; then
   exit 1
 fi
 
-if ! grep -Eq "Non-append slot drift detected|method_lookup index drift|InternalCall method order drift" <<< "$guard_output"; then
-  echo "FAIL: guard failed for fixture but did not report expected drift diagnostics." >&2
+if ! grep -Eq "Non-append slot drift detected in immutable v1 baseline" <<< "$guard_output"; then
+  echo "FAIL: guard failed but did not hit the immutable baseline drift path." >&2
   echo "$guard_output" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Implemented Phase B interop governance deliverables for #13.
- Added the v1 canonical contract map in docs/software/INTEROP_CONTRACT_V1.md.
- Added the v1.x compatibility policy in docs/software/INTEROP_VERSIONING_POLICY.md.
- Enforced hard preflight gates for slot drift and checksum alignment in managed/native build paths.
- Added intentional negative drift fixture coverage with toolchain/interop-negative-drift-test.sh and documented the workflow.
- Completed and closed child issues #41, #42, #43, and #44.

## Validation
- `cd software/nanoFramework && ./toolchain/interop-guard.sh`
- `cd software/nanoFramework && ./toolchain/interop-checksum.sh --check`
- `cd software/nanoFramework && ./toolchain/interop-negative-drift-test.sh`
- `cd software/nanoFramework && bash -n toolchain/build-managed.sh toolchain/build-native.sh toolchain/interop-guard.sh`

## Linked Issues
- Closes #13
- Closes #41
- Closes #42
- Closes #43
- Closes #44
