### PR TITLE
[Phase C] Harden Tier-0 mailbox latch semantics (issue #46)

### DIFF
--- a/docs/debug/DIAGNOSTICS_MAILBOX.md
+++ b/docs/debug/DIAGNOSTICS_MAILBOX.md
@@ -27,7 +27,11 @@ Current mailbox words are implemented as global volatile `uint32_t` symbols in:
    - Write policy: latch-once via `DiagnosticsMailbox.NativeTryLatchBootProbe(...)`.
    - Encoding: stage `0xF0`, result = aggregate (`PASS`/`WARN`/`FAIL`), detail = hardware bitmap (`bit0=W5500 bit1=LNBH26 bit2=FRAM`).
 
-4. `g_cubley_diag_clr_status`
+4. `g_cubley_diag_boot_probe_latched`
+   - Role: explicit sticky latch state (`0` not latched, `1` latched).
+   - Write policy: native-only guard state used to enforce deterministic one-shot semantics.
+
+5. `g_cubley_diag_clr_status`
    - Role: sticky-ish CLR startup progress channel (written alongside CLR current status in startup helpers).
    - Write policy: written by CLR startup diagnostic emitters.
 
@@ -51,7 +55,8 @@ Interop declarations are in:
 
 - `NativeTryLatchBootProbe(uint statusWord)`
   - Returns `true` on first successful latch.
-  - Returns `false` if already latched.
+   - Returns `false` if already latched.
+   - Returns `false` for invalid probe words (wrong magic or wrong stage).
 - `NativeGetBootProbe()`
   - Returns latched boot-probe word (or `0` if not yet latched).
 
@@ -117,7 +122,8 @@ Use these rules to avoid clobber races and ambiguous traces:
 2. CLR startup diagnostics write to `g_cubley_diag_clr_status` (and may mirror to current status).
 3. Runtime breadcrumbs (LED/network/etc.) may write `g_cubley_diag_current_status`.
 4. Error paths write `g_cubley_diag_last_error`.
-5. Do not clear sticky slots from normal runtime code.
+5. Latch state is enforced by `g_cubley_diag_boot_probe_latched`, not by interpreting probe word value.
+6. Do not clear sticky slots from normal runtime code.
 
 ## SWD Usage
 
@@ -173,6 +179,10 @@ If native interop method signatures changed, rebuild/flash nanoCLR before valida
    - Expected; this slot is transient and intentionally clobberable.
    - Use `Boot probe` slot for stable hardware-present bitmap.
 
-3. Magic byte mismatch warnings
+3. `NativeTryLatchBootProbe()` returns false while boot probe is still `0`
+   - Input word likely failed validation (magic byte must be `0xD5`, stage must be `0xF0`).
+   - Check `g_cubley_diag_last_error` for Tier-0 guard diagnostics (`0xE3` family).
+
+4. Magic byte mismatch warnings
    - Indicates either uninitialized data, different producer encoding, or stale symbol assumptions in scripts.
    - Re-check symbol names against current ELF.

--- a/docs/debug/TESTING_GUIDE.md
+++ b/docs/debug/TESTING_GUIDE.md
@@ -10,15 +10,12 @@ defined in:
 
 > **[PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md](./PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md)**
 
-Phase A exit is also gated by the [Phase A Exit Gate](./PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md#phase-a-exit-gate) section in that document.
+Phase A exit is also gated by the [Phase A Exit Gate](./PHASE_A_FUNCTIONAL_SMOKE_CHECKS.md#phase-a-exit-gate) section in that document.
+
 
 ## Current Profile Notes
 
-- The currently validated build profile has `System.Net` disabled.
-- MQTT/network test phases in this guide are optional unless networking is re-enabled in the build profile.
-
-## Prerequisites
-
+- Tier-0 mailbox semantics check: run `./software/nanoFramework/tests/tier0_interop_semantics_check.sh` and require `PASS`.
 ### Hardware Needed
 - ✅ STM32F407VGT6 DiSEqC controller board (assembled)
 - ✅ USB-to-Serial adapter (for debug output) - USART3 on PB10/PB11

--- a/software/nanoFramework/nf-native/cubley_interop.cpp
+++ b/software/nanoFramework/nf-native/cubley_interop.cpp
@@ -50,7 +50,18 @@ HRESULT Library_cubley_interop_UsbCdcConsole_NativeWrite___STATIC__I4__STRING(CL
 volatile uint32_t g_cubley_diag_current_status;
 volatile uint32_t g_cubley_diag_last_error = 0;
 volatile uint32_t g_cubley_diag_boot_probe_status = 0;
+volatile uint32_t g_cubley_diag_boot_probe_latched = 0;
 volatile uint32_t g_cubley_diag_clr_status = 0;
+
+static const uint32_t kCubleyStatusMagicMask = 0xFF000000u;
+static const uint32_t kCubleyStatusMagic = 0xD5000000u;
+static const uint8_t kCubleyBootProbeStage = 0xF0u;
+
+static inline void set_tier0_interop_error(uint8_t op, uint8_t code, uint8_t detail)
+{
+    // 0xE3 marker reserved for Tier-0 interop guard diagnostics.
+    g_cubley_diag_last_error = ((uint32_t)0xE3u << 24) | ((uint32_t)op << 16) | ((uint32_t)code << 8) | (uint32_t)detail;
+}
 
 static const CLR_RT_MethodHandler method_lookup[] =
 {
@@ -207,14 +218,32 @@ HRESULT Library_cubley_interop_DiagnosticsMailbox_NativeTryLatchBootProbe___STAT
     NANOCLR_HEADER();
 
     const uint32_t statusWord = stack.Arg0().NumericByRef().u4;
-    const bool latched = (g_cubley_diag_boot_probe_status == 0);
 
-    if (latched)
+    if (g_cubley_diag_boot_probe_latched != 0)
     {
-        g_cubley_diag_boot_probe_status = statusWord;
+        stack.SetResult_Boolean(false);
+        NANOCLR_NOCLEANUP_NOLABEL();
     }
 
-    stack.SetResult_Boolean(latched);
+    if ((statusWord & kCubleyStatusMagicMask) != kCubleyStatusMagic)
+    {
+        set_tier0_interop_error(0x01u, 0x01u, (uint8_t)((statusWord >> 24) & 0xFFu));
+        stack.SetResult_Boolean(false);
+        NANOCLR_NOCLEANUP_NOLABEL();
+    }
+
+    const uint8_t stage = (uint8_t)((statusWord >> 16) & 0xFFu);
+    if (stage != kCubleyBootProbeStage)
+    {
+        set_tier0_interop_error(0x01u, 0x02u, stage);
+        stack.SetResult_Boolean(false);
+        NANOCLR_NOCLEANUP_NOLABEL();
+    }
+
+    g_cubley_diag_boot_probe_status = statusWord;
+    g_cubley_diag_boot_probe_latched = 1;
+
+    stack.SetResult_Boolean(true);
     NANOCLR_NOCLEANUP_NOLABEL();
 }
 

--- a/software/nanoFramework/tests/tier0_interop_semantics_check.sh
+++ b/software/nanoFramework/tests/tier0_interop_semantics_check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NF_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+NATIVE_PATH="$NF_ROOT/nf-native/cubley_interop.cpp"
+
+if [[ ! -f "$NATIVE_PATH" ]]; then
+  echo "Native interop file not found: $NATIVE_PATH" >&2
+  exit 1
+fi
+
+python3 - "$NATIVE_PATH" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+
+required_global = "volatile uint32_t g_cubley_diag_boot_probe_latched = 0;"
+if required_global not in text:
+    raise SystemExit("FAIL: missing explicit boot probe latch state global")
+
+fn_match = re.search(
+    r"HRESULT\s+Library_cubley_interop_DiagnosticsMailbox_NativeTryLatchBootProbe___STATIC__BOOLEAN__U4\s*\(CLR_RT_StackFrame&\s+stack\)\s*\{(?P<body>.*?)\n\}",
+    text,
+    flags=re.S,
+)
+if not fn_match:
+    raise SystemExit("FAIL: unable to locate NativeTryLatchBootProbe implementation")
+
+body = fn_match.group("body")
+
+required_snippets = [
+    "g_cubley_diag_boot_probe_latched != 0",
+    "(statusWord & kCubleyStatusMagicMask) != kCubleyStatusMagic",
+    "stage != kCubleyBootProbeStage",
+    "g_cubley_diag_boot_probe_status = statusWord;",
+    "g_cubley_diag_boot_probe_latched = 1;",
+]
+
+for snippet in required_snippets:
+    if snippet not in body:
+        raise SystemExit(f"FAIL: expected snippet not found in latch function: {snippet}")
+
+if "g_cubley_diag_current_status" in body:
+    raise SystemExit("FAIL: latch function should not write transient current status")
+
+print("PASS: Tier-0 interop latch semantics guardrails are present.")
+PYEOF


### PR DESCRIPTION
## Summary
- Hardened Tier-0 diagnostics mailbox latch semantics in native interop.
- Added explicit sticky latch state (`g_cubley_diag_boot_probe_latched`) instead of inferring latch state from probe word value.
- Tightened `DiagnosticsMailbox.NativeTryLatchBootProbe` validation:
  - reject invalid magic (must be `0xD5`),
  - reject invalid stage (must be `0xF0`),
  - preserve one-shot behavior deterministically.
- Added static Tier-0 semantics regression check script:
  - `software/nanoFramework/tests/tier0_interop_semantics_check.sh`
- Updated diagnostics/testing docs with the revised semantics and validation step.

## Validation
- `cd software/nanoFramework && ./tests/tier0_interop_semantics_check.sh`
- `cd software/nanoFramework && ./toolchain/interop-guard.sh`
- `cd software/nanoFramework && ./toolchain/interop-checksum.sh --check`

## Linked Issue
- Ref #46

## Remaining Work
- Board-level repeated reset-cycle smoke verification is still pending and will be completed before closing #46.
