### PR TITLE
Devcontainer: add jq and xxd tooling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,7 +86,9 @@ RUN apt-get install -y --no-install-recommends \
     picocom \
     minicom \
     strace \
-    tio
+    tio \
+    xxd \
+    jq
 
 # ---- GitHub CLI ----
 RUN mkdir -p -m 755 /etc/apt/keyrings \


### PR DESCRIPTION
## Summary
- Add `jq` to the devcontainer image for JSON-oriented CLI workflows.
- Add `xxd` to the devcontainer image for quick binary/hex inspection during bringup and diagnostics.

## Why
These tooling additions support day-to-day debugging and automation tasks without requiring ad-hoc package installs in each container session.

## Change scope
- `.devcontainer/Dockerfile`

## Validation
- Build should continue using existing apt package flow in the Dockerfile.
