### PR TITLE
Rebaseline Phase B interop governance on cubley-base

### DIFF
--- a/.github/workflows/interop-guard.yml
+++ b/.github/workflows/interop-guard.yml
@@ -8,6 +8,7 @@ on:
       - software/nanoFramework/nf-native/cubley_interop.cpp
       - software/nanoFramework/toolchain/interop-checksum.sh
       - software/nanoFramework/toolchain/interop-guard.sh
+      - software/nanoFramework/toolchain/interop-negative-drift-test.sh
       - software/nanoFramework/tests/DiSEqC_Control.Tests/**
       - .github/workflows/interop-guard.yml
   push:
@@ -19,6 +20,7 @@ on:
       - software/nanoFramework/nf-native/cubley_interop.cpp
       - software/nanoFramework/toolchain/interop-checksum.sh
       - software/nanoFramework/toolchain/interop-guard.sh
+      - software/nanoFramework/toolchain/interop-negative-drift-test.sh
       - software/nanoFramework/tests/DiSEqC_Control.Tests/**
       - .github/workflows/interop-guard.yml
 
@@ -37,6 +39,11 @@ jobs:
           cd software/nanoFramework
           ./toolchain/interop-checksum.sh --check
           ./toolchain/interop-guard.sh
+
+      - name: Verify intentional negative drift fixture blocks
+        run: |
+          cd software/nanoFramework
+          ./toolchain/interop-negative-drift-test.sh
 
       - name: Run host-side interop contract tests
         run: |

--- a/docs/debug/PHASE_A_EXIT_DECISION_2026-06-07.md
+++ b/docs/debug/PHASE_A_EXIT_DECISION_2026-06-07.md
@@ -1,5 +1,12 @@
 # Phase A Exit Decision Record (2026-06-07)
 
+> Status update (2026-06-08): This decision record is historical and was
+> superseded by the cubley-base program re-baseline decision in
+> [getpwnam/diseqc_cntrl#52](https://github.com/getpwnam/diseqc_cntrl/issues/52).
+> Use [PHASE_A_BASELINE.md](./PHASE_A_BASELINE.md) as the authoritative current
+> baseline reference. Mentions of `cubley-stable` below are legacy context from
+> the original 2026-06-07 freeze point.
+
 ## Decision
 
 **Phase A is exited and frozen** as of 2026-06-07.

--- a/software/nanoFramework/README.md
+++ b/software/nanoFramework/README.md
@@ -65,11 +65,11 @@ Builds firmware artifacts by fetching/using `nf-interpreter` inside Docker and c
 Commands (recommended wrapper):
 
 - Cubley base profile (default/canonical): `./toolchain/build-native.sh build --profile cubley-base`
-- Cubley W5500-native profile: `./toolchain/build-native.sh build --profile cubley-uart`
-- Cubley USB bring-up profile (no-VBUS-sense default): `./toolchain/build-native.sh build --profile cubley-usb`
-- Cubley hardalive profile (PA2 + PB10 hard toggle, no RTOS/CLR): `./toolchain/build-native.sh build --profile cubley-hardalive`
-- Bring-up smoke diagnostic profile (PA2 blink + USART3 heartbeat): `./toolchain/build-native.sh build --profile bringup-smoke`
-- Core-only diagnostic profile: `./toolchain/build-native.sh build --profile core-only`
+- Cubley W5500-native profile (reference-only): `NF_ALLOW_REFERENCE_PROFILE=1 ./toolchain/build-native.sh build --profile cubley-uart`
+- Cubley USB bring-up profile (no-VBUS-sense default, reference-only): `NF_ALLOW_REFERENCE_PROFILE=1 ./toolchain/build-native.sh build --profile cubley-usb`
+- Cubley hardalive profile (PA2 + PB10 hard toggle, no RTOS/CLR, reference-only): `NF_ALLOW_REFERENCE_PROFILE=1 ./toolchain/build-native.sh build --profile cubley-hardalive`
+- Bring-up smoke diagnostic profile (PA2 blink + USART3 heartbeat, reference-only): `NF_ALLOW_REFERENCE_PROFILE=1 ./toolchain/build-native.sh build --profile bringup-smoke`
+- Core-only diagnostic profile (reference-only): `NF_ALLOW_REFERENCE_PROFILE=1 ./toolchain/build-native.sh build --profile core-only`
 
 Reference-only profile safety gate:
 

--- a/software/nanoFramework/README.md
+++ b/software/nanoFramework/README.md
@@ -64,12 +64,17 @@ Builds firmware artifacts by fetching/using `nf-interpreter` inside Docker and c
 
 Commands (recommended wrapper):
 
-- Cubley stable profile (default): `./toolchain/build-native.sh build --profile cubley-stable`
+- Cubley base profile (default/canonical): `./toolchain/build-native.sh build --profile cubley-base`
 - Cubley W5500-native profile: `./toolchain/build-native.sh build --profile cubley-uart`
 - Cubley USB bring-up profile (no-VBUS-sense default): `./toolchain/build-native.sh build --profile cubley-usb`
 - Cubley hardalive profile (PA2 + PB10 hard toggle, no RTOS/CLR): `./toolchain/build-native.sh build --profile cubley-hardalive`
 - Bring-up smoke diagnostic profile (PA2 blink + USART3 heartbeat): `./toolchain/build-native.sh build --profile bringup-smoke`
 - Core-only diagnostic profile: `./toolchain/build-native.sh build --profile core-only`
+
+Reference-only profile safety gate:
+
+- Non-base profiles are blocked by default.
+- To run intentionally: `NF_ALLOW_REFERENCE_PROFILE=1 ./toolchain/build-native.sh build --profile <profile>`
 
 Deprecated profile quarantine:
 
@@ -80,12 +85,13 @@ Deprecated profile quarantine:
 
 | Profile | Status | Primary Purpose | Key Traits |
 |---|---|---|---|
-| `cubley-stable` | stable | Default daily firmware | Non-network, config block on, RTC on, UART wire protocol |
-| `cubley-uart` | scaffold | Native W5500 bring-up | Non-network, config block off, SPI/GPIO/I2C on |
-| `cubley-usb` | experimental | USB-first transport bring-up | OTG1 + USB serial enabled; VBUS-sense mode selectable |
-| `cubley-hardalive` | experimental | Bare-metal liveness check | No RTOS/CLR startup; hard pin toggles |
-| `bringup-smoke` | experimental | Fast smoke diagnostics | PA2 blink + USART3 heartbeat |
-| `core-only` | experimental | Fast firmware iteration | Smallest managed/API footprint |
+| `cubley-base` | canonical | Default baseline firmware | Minimal UART3 wire-protocol baseline on `M0DMF_CUBLEY_V0.4` |
+| `cubley-stable` | reference-only | Historical stable comparison profile | Non-network, config block on, RTC on, UART wire protocol |
+| `cubley-uart` | reference-only | Native W5500 bring-up scaffold | Non-network, config block off, SPI/GPIO/I2C on |
+| `cubley-usb` | reference-only | USB-first transport bring-up | OTG1 + USB serial enabled; VBUS-sense mode selectable |
+| `cubley-hardalive` | reference-only | Bare-metal liveness check | No RTOS/CLR startup; hard pin toggles |
+| `bringup-smoke` | reference-only | Fast smoke diagnostics | PA2 blink + USART3 heartbeat |
+| `core-only` | reference-only | Fast firmware iteration | Smallest managed/API footprint |
 | `legacy-network` | deprecated | Transitional compatibility only | lwIP/System.Net path; gated by env var |
 
 The wrapper auto-runs inside Docker when invoked from host Linux/WSL, and also works when already inside the container.


### PR DESCRIPTION
## Summary
- align interop CI gating by adding the intentional negative drift fixture to the Interop Guard workflow triggers and execution
- update nanoFramework build documentation to mark `cubley-base` as canonical default and non-base profiles as reference-only opt-in
- mark the 2026-06-07 Phase A exit record as historical/superseded by decision #52 to avoid stale `cubley-stable` baseline interpretation
- revisit Phase B issue bodies (#13, #41, #42, #43, #44) to match cubley-base re-baseline sequencing and dependencies

## Validation
- `cd software/nanoFramework && ./toolchain/interop-negative-drift-test.sh`
- `cd software/nanoFramework && ./toolchain/interop-guard.sh`
- `cd software/nanoFramework && ./toolchain/interop-checksum.sh --check`

## Issue Link
Refs #13
Refs #41
Refs #42
Refs #43
Refs #44
