### PR TITLE
[Phase C] #46 Tier-0/Tier-1 smoke harness and reliability gate

### DIFF
--- a/docs/debug/BRINGUP_TEST_LOG.md
+++ b/docs/debug/BRINGUP_TEST_LOG.md
@@ -1196,3 +1196,10 @@ This file should be committed and checked on each build to prevent version drift
 - Command(s): ./toolchain/run-deterministic-cycles.sh --cycles 20 --serial /dev/ttyUSB0 --baud 115200 --settle-ms 2000
 - Artifact: .debug/issue26_campaign_20260608T142844Z
 - Conclusion: Deterministic 20-cycle flash-reset rerun completed with fails=0/20.
+
+### 2026-06-08 15:25:40 UTC [PASS] [NON-BASELINE]
+- Git rev: 07b6213
+- Baseline: NO — deviates from cubley-base Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): ./toolchain/build-managed.sh build --project CubleySmokeTier0/CubleySmokeTier0.nfproj --deploy --swd --address 0x080C0000 --reset && /workspaces/diseqc_cntrl/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh --cycles 20 --read-count 4 --stop-on-fail
+- Artifact: build/CubleySmokeTier0/CubleySmokeTier0.bin
+- Conclusion: CubleySmokeTier0 completed Tier-0/Tier-1 interop harness run; Tier-0 reset-cycle smoke passed 20/20 with stable boot-probe latch 0xD5F00111.

--- a/docs/debug/DIAGNOSTICS_MAILBOX.md
+++ b/docs/debug/DIAGNOSTICS_MAILBOX.md
@@ -125,6 +125,7 @@ Primary helper scripts:
 
 - `tests/swd_read_bringup_status.sh`
 - `tests/swd_read_w5500_diag.sh`
+- `tests/tier0_mailbox_reliability_smoke.sh`
 
 ### Read all high-level slots
 
@@ -147,6 +148,34 @@ cd software/nanoFramework
 ```
 
 This includes the generic mailbox/error slots plus W5500-specific latches and decode hints.
+
+### Phase C Tier-0 Reliability Smoke
+
+Run repeated reset/read cycles and enforce sticky boot-probe invariants:
+
+```bash
+cd software/nanoFramework
+./tests/tier0_mailbox_reliability_smoke.sh --cycles 10 --read-count 4
+```
+
+Expected behavior:
+
+- Each cycle reports `PASS` with stable `boot_probe` value across repeated reads.
+- `boot_probe`, `clr_status`, and `current_status` words retain valid `0xD5` magic and known result-code encoding.
+- Final summary reports `fails=0/<cycles>`.
+
+Recommended managed payload for firmware-first smoke campaigns:
+
+- `CubleySmokeTier0` (`software/nanoFramework/CubleySmokeTier0/CubleySmokeTier0.nfproj`)
+
+Build/deploy example:
+
+```bash
+cd software/nanoFramework
+./toolchain/build-managed.sh build \
+   --project CubleySmokeTier0/CubleySmokeTier0.nfproj \
+   --deploy --swd --address 0x080C0000 --reset
+```
 
 ## Build and Compatibility Notes
 

--- a/software/nanoFramework/CubleySmokeTier0/CubleySmokeTier0.nfproj
+++ b/software/nanoFramework/CubleySmokeTier0/CubleySmokeTier0.nfproj
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{A7D2EAF6-9AB3-4A4A-8922-4ED77FBB4D4A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>CubleySmokeTier0</RootNamespace>
+    <AssemblyName>CubleySmokeTier0</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading">
+      <HintPath>..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Cubley.Interop\Cubley.Interop.nfproj">
+      <Project>{E65B3A56-704A-4E42-88E3-9E3A2E35B641}</Project>
+      <Name>Cubley.Interop</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/software/nanoFramework/CubleySmokeTier0/Program.cs
+++ b/software/nanoFramework/CubleySmokeTier0/Program.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Threading;
+using Cubley.Interop;
+
+namespace CubleySmokeTier0
+{
+    public static class Program
+    {
+        private const byte ResultEnter = 0;
+        private const byte ResultPass = 1;
+        private const byte ResultWarn = 2;
+        private const byte ResultFail = 14;
+
+        private const byte StageStart = 0xC0;
+        private const byte StageTier0 = 0xC1;
+        private const byte StageTier1 = 0xC2;
+        private const byte StageFinal = 0xCF;
+
+        private const uint LatchWord = 0xD5F00111;
+        private const uint LatchOverwriteAttemptWord = 0xD5F00E22;
+
+        public static void Main()
+        {
+            // Smoke contract for firmware-first interop validation:
+            // - BringupStatus (Tier-0): write 0xD5SSRRDD markers with NativeSet(), then
+            //   verify NativeGet() returns the exact marker value for round-trip integrity.
+            // - DiagnosticsMailbox (Tier-0): write LatchWord (0xD5F00111) via
+            //   NativeTryLatchBootProbe(); expected first call=true and NativeGetBootProbe()==LatchWord.
+            //   Then attempt overwrite with LatchOverwriteAttemptWord (0xD5F00E22);
+            //   expected second call=false and NativeGetBootProbe() unchanged (still LatchWord).
+            // - StatusLed (Tier-1): NativeInit/NativeSetLow/NativePulse are invoked; expected
+            //   behavior is successful non-throwing execution.
+            // - UsbCdcConsole (Tier-1): NativeIsEnabled/NativeReadByte(0)/NativeWrite(...)
+            //   are invoked; expected read result >= -1 (timeout is -1) and write >= 0 when USB
+            //   CDC is enabled.
+            byte detail = 0;
+            bool pass = true;
+
+            BringupStatus.NativeSet(Compose(StageStart, ResultEnter, 0x01));
+
+            try
+            {
+                // Tier-0 smoke: set/get + boot-probe latch one-shot semantics.
+                BringupStatus.NativeSet(Compose(StageTier0, ResultEnter, 0x01));
+
+                uint marker = Compose(StageTier0, ResultPass, 0x10);
+                BringupStatus.NativeSet(marker);
+                uint markerRead = BringupStatus.NativeGet();
+                if (markerRead == marker)
+                {
+                    detail |= 0x01;
+                }
+                else
+                {
+                    pass = false;
+                }
+
+                bool firstLatched = DiagnosticsMailbox.NativeTryLatchBootProbe(LatchWord);
+                uint bootAfterFirst = DiagnosticsMailbox.NativeGetBootProbe();
+                if (firstLatched)
+                {
+                    detail |= 0x02;
+                }
+                else
+                {
+                    pass = false;
+                }
+
+                bool secondLatched = DiagnosticsMailbox.NativeTryLatchBootProbe(LatchOverwriteAttemptWord);
+                uint bootAfterSecond = DiagnosticsMailbox.NativeGetBootProbe();
+                if (!secondLatched)
+                {
+                    detail |= 0x04;
+                }
+                else
+                {
+                    pass = false;
+                }
+
+                if (bootAfterFirst == LatchWord && bootAfterSecond == LatchWord)
+                {
+                    detail |= 0x08;
+                }
+                else
+                {
+                    pass = false;
+                }
+
+                BringupStatus.NativeSet(Compose(StageTier0, pass ? ResultPass : ResultFail, detail));
+            }
+            catch
+            {
+                pass = false;
+                BringupStatus.NativeSet(Compose(StageTier0, ResultFail, detail));
+            }
+
+            try
+            {
+                // Tier-1 smoke: LED and USB console interop should execute without exceptions.
+                BringupStatus.NativeSet(Compose(StageTier1, ResultEnter, detail));
+
+                StatusLed.NativeInit();
+                StatusLed.NativeSetLow();
+                StatusLed.NativePulse(1, 50);
+                detail |= 0x10;
+
+                bool usbEnabled = UsbCdcConsole.NativeIsEnabled();
+                int readByte = UsbCdcConsole.NativeReadByte(0);
+                int writeRc = usbEnabled ? UsbCdcConsole.NativeWrite("CubleySmokeTier0 ready\r\n") : 0;
+
+                // Read timeout (-1) is valid for immediate mode; only enforce minimal call success.
+                if (readByte >= -1)
+                {
+                    detail |= 0x20;
+                }
+                else
+                {
+                    pass = false;
+                }
+
+                if (!usbEnabled || writeRc >= 0)
+                {
+                    detail |= 0x40;
+                }
+                else
+                {
+                    pass = false;
+                }
+
+                BringupStatus.NativeSet(Compose(StageTier1, pass ? ResultPass : ResultWarn, detail));
+            }
+            catch
+            {
+                pass = false;
+                BringupStatus.NativeSet(Compose(StageTier1, ResultFail, detail));
+            }
+
+            BringupStatus.NativeSet(Compose(StageFinal, pass ? ResultPass : ResultFail, detail));
+
+            while (true)
+            {
+                Thread.Sleep(1000);
+            }
+        }
+
+        private static uint Compose(byte stage, byte result, byte detail)
+        {
+            return ((uint)0xD5 << 24) | ((uint)stage << 16) | ((uint)result << 8) | detail;
+        }
+    }
+}

--- a/software/nanoFramework/CubleySmokeTier0/Program.cs
+++ b/software/nanoFramework/CubleySmokeTier0/Program.cs
@@ -97,6 +97,7 @@ namespace CubleySmokeTier0
             try
             {
                 // Tier-1 smoke: LED and USB console interop should execute without exceptions.
+                bool tier1Pass = true;
                 BringupStatus.NativeSet(Compose(StageTier1, ResultEnter, detail));
 
                 StatusLed.NativeInit();
@@ -115,7 +116,7 @@ namespace CubleySmokeTier0
                 }
                 else
                 {
-                    pass = false;
+                    tier1Pass = false;
                 }
 
                 if (!usbEnabled || writeRc >= 0)
@@ -124,10 +125,11 @@ namespace CubleySmokeTier0
                 }
                 else
                 {
-                    pass = false;
+                    tier1Pass = false;
                 }
 
-                BringupStatus.NativeSet(Compose(StageTier1, pass ? ResultPass : ResultWarn, detail));
+                BringupStatus.NativeSet(Compose(StageTier1, tier1Pass ? ResultPass : ResultFail, detail));
+                pass = pass && tier1Pass;
             }
             catch
             {

--- a/software/nanoFramework/CubleySmokeTier0/Properties/AssemblyInfo.cs
+++ b/software/nanoFramework/CubleySmokeTier0/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("CubleySmokeTier0")]
+[assembly: AssemblyDescription("Minimal Tier-0/Tier-1 interop smoke harness")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CubleySmokeTier0")]
+[assembly: AssemblyCopyright("Copyright © 2026")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/software/nanoFramework/CubleySmokeTier0/packages.config
+++ b/software/nanoFramework/CubleySmokeTier0/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
+</packages>

--- a/software/nanoFramework/DiSEqC_Control/DiSEqC_Control.nfproj
+++ b/software/nanoFramework/DiSEqC_Control/DiSEqC_Control.nfproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <!-- MQTT-first build. Rotor/LNB/Fram/Serial are excluded until their native
          InternalCall bindings are registered as g_CLR_AssemblyNative_DiSEqC_Control. -->
+    <Compile Include="DiagnosticsStatusWord.cs" />
     <Compile Include="FramConfigurationStorage.cs" />
     <Compile Include="HardwareCapabilities.cs" />
     <!-- <Compile Include="Manager\RotorManagerNative.cs" /> -->

--- a/software/nanoFramework/tests/README.md
+++ b/software/nanoFramework/tests/README.md
@@ -70,3 +70,76 @@ cd software/nanoFramework/tests
 chmod +x mqtt_topic_watch.sh
 ./mqtt_topic_watch.sh mqtt.ebnx.net 1883 'diseqc/#'
 ```
+
+## 3) Tier-0 Mailbox Reliability Smoke (Phase C)
+
+Use this script to validate Tier-0 mailbox semantics (`BringupStatus` and
+`DiagnosticsMailbox`) across repeated reset/read cycles.
+
+It verifies:
+
+- `g_cubley_diag_boot_probe_status` is latched (non-zero) and remains sticky within each cycle.
+- status words decode with valid `0xD5SSRRDD` magic/result format.
+- reset-cycle repetition does not break basic Tier-0 mailbox reads.
+
+Command:
+
+```bash
+cd software/nanoFramework
+chmod +x tests/tier0_mailbox_reliability_smoke.sh
+./tests/tier0_mailbox_reliability_smoke.sh --cycles 10 --read-count 4
+```
+
+If your default `build/nanoCLR.elf` is stripped, the script auto-selects a
+symbolized profile ELF when available.
+
+Optional explicit override:
+
+```bash
+./tests/tier0_mailbox_reliability_smoke.sh \
+	--cycles 10 \
+	--read-count 4 \
+	--elf build/nf-interpreter/M0DMF_CUBLEY_F407/nanoCLR.elf
+```
+
+Prerequisites:
+
+- `st-flash`, `openocd`, and `arm-none-eabi-gdb` (or `gdb-multiarch`/`gdb`)
+- Built `build/nanoCLR.elf`
+- Connected ST-Link target
+
+Tip:
+
+- Use `--stop-on-fail` during triage to halt on the first failing cycle.
+
+## 4) CubleySmokeTier0 Managed Harness
+
+`CubleySmokeTier0` is a minimal managed app for firmware-first smoke coverage.
+It exercises only Tier-0/Tier-1 interop calls and avoids full `DiSEqC_Control`
+runtime complexity.
+
+Project path:
+
+- `software/nanoFramework/CubleySmokeTier0/CubleySmokeTier0.nfproj`
+
+Build and deploy by SWD:
+
+```bash
+cd software/nanoFramework
+./toolchain/build-managed.sh build \
+	--project CubleySmokeTier0/CubleySmokeTier0.nfproj \
+	--deploy --swd --address 0x080C0000 --reset
+```
+
+Then run Tier-0 reliability smoke:
+
+```bash
+cd /workspaces/diseqc_cntrl
+./software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh --cycles 10 --read-count 4 --stop-on-fail
+```
+
+Harness behaviors:
+
+- Tier-0: `BringupStatus` set/get round-trip and `DiagnosticsMailbox` latch-once checks.
+- Tier-1: `StatusLed` and `UsbCdcConsole` calls for non-throwing execution verification.
+- Final marker: writes a deterministic status word so SWD readers can confirm run completion.

--- a/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh
+++ b/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh
@@ -244,6 +244,8 @@ EOF_GDB
   done
 
   kill "$openocd_pid" >/dev/null 2>&1 || true
+  # Avoid port 3333 contention between samples: ensure OpenOCD fully exits before the next run.
+  wait "$openocd_pid" >/dev/null 2>&1 || true
 
   if [[ -z "$current_hex" || -z "$boot_probe_hex" || -z "$clr_hex" ]]; then
     echo "ERROR: failed to read diagnostics symbols for sample '$sample_id' after ${gdb_max_attempts} attempts." >&2

--- a/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh
+++ b/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./tests/tier0_mailbox_reliability_smoke.sh [options]
+
+Run repeated reset/read cycles and validate Tier-0 diagnostics mailbox invariants.
+
+Options:
+  --cycles <n>                 Number of reset cycles (default: 10)
+  --settle-ms <ms>             Delay after reset before first sample (default: 1200)
+  --read-count <n>             Number of repeated reads per cycle (default: 4)
+  --read-delay-ms <ms>         Delay between repeated reads (default: 150)
+  --boot-probe-timeout-ms <ms> Max wait for boot-probe latch to become non-zero (default: 6000)
+  --boot-probe-poll-ms <ms>    Poll interval while waiting for boot-probe latch (default: 250)
+  --elf <path>                 Path to nanoCLR ELF (default: build/nanoCLR.elf)
+  --openocd-cfg <args>         OpenOCD cfg args string (default: "interface/stlink.cfg -f target/stm32f4x.cfg")
+  --stop-on-fail               Stop at first failed cycle
+  -h, --help                   Show this help
+
+Exit codes:
+  0 if all cycles pass, 1 otherwise.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NF_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/phase_a_result_codec.sh"
+
+CYCLES=10
+SETTLE_MS=1200
+READ_COUNT=4
+READ_DELAY_MS=150
+BOOT_PROBE_TIMEOUT_MS=6000
+BOOT_PROBE_POLL_MS=250
+ELF_PATH="$NF_ROOT/build/nanoCLR.elf"
+ELF_EXPLICIT=0
+OPENOCD_CFG="interface/stlink.cfg -f target/stm32f4x.cfg"
+STOP_ON_FAIL=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cycles)
+      CYCLES="${2:-}"
+      shift 2
+      ;;
+    --settle-ms)
+      SETTLE_MS="${2:-}"
+      shift 2
+      ;;
+    --read-count)
+      READ_COUNT="${2:-}"
+      shift 2
+      ;;
+    --read-delay-ms)
+      READ_DELAY_MS="${2:-}"
+      shift 2
+      ;;
+    --boot-probe-timeout-ms)
+      BOOT_PROBE_TIMEOUT_MS="${2:-}"
+      shift 2
+      ;;
+    --boot-probe-poll-ms)
+      BOOT_PROBE_POLL_MS="${2:-}"
+      shift 2
+      ;;
+    --elf)
+      ELF_PATH="${2:-}"
+      ELF_EXPLICIT=1
+      shift 2
+      ;;
+    --openocd-cfg)
+      OPENOCD_CFG="${2:-}"
+      shift 2
+      ;;
+    --stop-on-fail)
+      STOP_ON_FAIL=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "${GDB_BIN:-}" ]]; then
+  GDB_BIN="$GDB_BIN"
+elif command -v arm-none-eabi-gdb >/dev/null 2>&1; then
+  GDB_BIN="arm-none-eabi-gdb"
+elif command -v gdb-multiarch >/dev/null 2>&1; then
+  GDB_BIN="gdb-multiarch"
+else
+  GDB_BIN="gdb"
+fi
+
+OPENOCD_BIN="${OPENOCD_BIN:-openocd}"
+
+require_nonneg_int() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "Error: $name must be a non-negative integer." >&2
+    exit 2
+  fi
+}
+
+require_pos_int() {
+  local name="$1"
+  local value="$2"
+  require_nonneg_int "$name" "$value"
+  if [[ "$value" -le 0 ]]; then
+    echo "Error: $name must be > 0." >&2
+    exit 2
+  fi
+}
+
+require_pos_int "--cycles" "$CYCLES"
+require_nonneg_int "--settle-ms" "$SETTLE_MS"
+require_pos_int "--read-count" "$READ_COUNT"
+require_nonneg_int "--read-delay-ms" "$READ_DELAY_MS"
+require_pos_int "--boot-probe-timeout-ms" "$BOOT_PROBE_TIMEOUT_MS"
+require_pos_int "--boot-probe-poll-ms" "$BOOT_PROBE_POLL_MS"
+
+if [[ ! -f "$ELF_PATH" ]]; then
+  echo "ELF not found: $ELF_PATH" >&2
+  exit 1
+fi
+
+if ! command -v "$OPENOCD_BIN" >/dev/null 2>&1; then
+  echo "openocd not found (override with OPENOCD_BIN)." >&2
+  exit 1
+fi
+
+if ! command -v "$GDB_BIN" >/dev/null 2>&1; then
+  echo "gdb not found (override with GDB_BIN)." >&2
+  exit 1
+fi
+
+has_required_diag_symbols() {
+  local elf="$1"
+  "$GDB_BIN" -q -batch \
+    -ex "file $elf" \
+    -ex "info address g_cubley_diag_current_status" \
+    -ex "info address g_cubley_diag_boot_probe_status" \
+    -ex "info address g_cubley_diag_clr_status" >/dev/null 2>&1
+}
+
+if ! has_required_diag_symbols "$ELF_PATH"; then
+  if [[ "$ELF_EXPLICIT" -eq 0 ]]; then
+    for candidate in \
+      "$NF_ROOT/build/nf-interpreter/M0DMF_CUBLEY_F407/nanoCLR.elf" \
+      "$NF_ROOT/build/nf-interpreter/M0DMF_CUBLEY_V0_4/nanoCLR.elf"; do
+      if [[ -f "$candidate" ]] && has_required_diag_symbols "$candidate"; then
+        ELF_PATH="$candidate"
+        break
+      fi
+    done
+  fi
+fi
+
+if ! has_required_diag_symbols "$ELF_PATH"; then
+  cat >&2 <<EOF
+ERROR: required diagnostics symbols were not found in ELF:
+  $ELF_PATH
+
+Use an unstripped nanoCLR ELF that contains:
+  - g_cubley_diag_current_status
+  - g_cubley_diag_boot_probe_status
+  - g_cubley_diag_clr_status
+
+Tip: pass an explicit image via --elf <path>.
+EOF
+  exit 1
+fi
+
+echo "Using ELF: $ELF_PATH"
+
+if ! command -v st-flash >/dev/null 2>&1; then
+  echo "st-flash not found on PATH." >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d /tmp/tier0-mailbox-smoke-XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+sleep_ms() {
+  local ms="$1"
+  if [[ "$ms" -gt 0 ]]; then
+    sleep "$(awk "BEGIN { printf \"%.3f\", $ms/1000 }")"
+  fi
+}
+
+read_mailboxes_once() {
+  local sample_id="$1"
+  local openocd_log="$tmp_dir/openocd_${sample_id}.log"
+  local gdb_cmd="$tmp_dir/read_${sample_id}.gdb"
+  local gdb_out="$tmp_dir/gdb_${sample_id}.out"
+  local gdb_attempt=0
+  local gdb_max_attempts=15
+
+  cat > "$gdb_cmd" <<'EOF_GDB'
+set pagination off
+set confirm off
+target extended-remote :3333
+monitor halt
+set $current_addr = &g_cubley_diag_current_status
+set $boot_probe_addr = &g_cubley_diag_boot_probe_status
+set $clr_addr = &g_cubley_diag_clr_status
+x/wx $current_addr
+x/wx $boot_probe_addr
+x/wx $clr_addr
+monitor resume
+quit
+EOF_GDB
+
+  "$OPENOCD_BIN" -f $OPENOCD_CFG >"$openocd_log" 2>&1 &
+  local openocd_pid=$!
+
+  local current_hex=""
+  local boot_probe_hex=""
+  local clr_hex=""
+
+  while [[ "$gdb_attempt" -lt "$gdb_max_attempts" ]]; do
+    if "$GDB_BIN" -q -batch -ex "file $ELF_PATH" -x "$gdb_cmd" >"$gdb_out" 2>&1; then
+      mapfile -t vals < <(sed -n 's/.*:\s*\(0x[0-9a-fA-F]\+\).*/\1/p' "$gdb_out")
+      if [[ ${#vals[@]} -ge 3 ]]; then
+        current_hex="${vals[0]}"
+        boot_probe_hex="${vals[1]}"
+        clr_hex="${vals[2]}"
+        break
+      fi
+    fi
+
+    gdb_attempt=$((gdb_attempt + 1))
+    sleep_ms 200
+  done
+
+  kill "$openocd_pid" >/dev/null 2>&1 || true
+
+  if [[ -z "$current_hex" || -z "$boot_probe_hex" || -z "$clr_hex" ]]; then
+    echo "ERROR: failed to read diagnostics symbols for sample '$sample_id' after ${gdb_max_attempts} attempts." >&2
+    echo "--- gdb output ---" >&2
+    cat "$gdb_out" >&2 || true
+    echo "--- openocd output ---" >&2
+    tail -n 50 "$openocd_log" >&2 || true
+    return 1
+  fi
+
+  printf '%s %s %s\n' "$current_hex" "$boot_probe_hex" "$clr_hex"
+  return 0
+}
+
+is_valid_result_code() {
+  local result="$1"
+  phase_a_result_label "$result" >/dev/null 2>&1
+}
+
+validate_status_word() {
+  local label="$1"
+  local value_hex="$2"
+  local value_dec=$((value_hex))
+  local magic=$(((value_dec >> 24) & 0xFF))
+  local stage=$(((value_dec >> 16) & 0xFF))
+  local result=$(((value_dec >> 8) & 0xFF))
+
+  if [[ "$magic" -ne $((0xD5)) ]]; then
+    echo "ERROR: $label has invalid magic (0x$(printf '%02X' "$magic"), expected 0xD5)." >&2
+    return 1
+  fi
+
+  if ! is_valid_result_code "$result"; then
+    echo "ERROR: $label has invalid result code $result (accepted: $(phase_a_result_contract_summary))." >&2
+    return 1
+  fi
+
+  # Tier-0 boot-probe aggregate should stay on stage 0xF0 (or legacy decimal 226).
+  if [[ "$label" == "boot_probe" && "$stage" -ne $((0xF0)) && "$stage" -ne 226 ]]; then
+    echo "ERROR: boot_probe stage changed to $stage (expected 240/0xF0 or legacy 226)." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+FAIL_COUNT=0
+
+printf 'tier0_mailbox_reliability_smoke: cycles=%s read_count=%s settle_ms=%s\n' "$CYCLES" "$READ_COUNT" "$SETTLE_MS"
+
+for cycle in $(seq 1 "$CYCLES"); do
+  cycle_id="$(printf '%02d' "$cycle")"
+  cycle_fail=0
+  printf '\n=== cycle %s ===\n' "$cycle_id"
+
+  if ! st-flash reset >/dev/null 2>&1; then
+    echo "cycle $cycle_id: FAIL (st-flash reset failed)" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+    continue
+  fi
+
+  sleep_ms "$SETTLE_MS"
+
+  # Wait until managed startup has had a chance to latch boot-probe, then validate.
+  probe_sample=""
+  deadline_ms=$(( $(date +%s%3N) + BOOT_PROBE_TIMEOUT_MS ))
+  while [[ $(date +%s%3N) -lt "$deadline_ms" ]]; do
+    if sample="$(read_mailboxes_once "${cycle_id}_wait")"; then
+      read -r current_hex boot_probe_hex clr_hex <<< "$sample"
+      if [[ "$boot_probe_hex" != "0x0" && "$boot_probe_hex" != "0x00000000" ]]; then
+        probe_sample="$sample"
+        break
+      fi
+    fi
+    sleep_ms "$BOOT_PROBE_POLL_MS"
+  done
+
+  if [[ -z "$probe_sample" ]]; then
+    echo "cycle $cycle_id: FAIL (boot_probe did not latch before timeout ${BOOT_PROBE_TIMEOUT_MS}ms)" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+    continue
+  fi
+
+  read -r first_current first_boot first_clr <<< "$probe_sample"
+
+  if ! validate_status_word "boot_probe" "$first_boot"; then
+    cycle_fail=1
+  fi
+
+  if ! validate_status_word "clr_status" "$first_clr"; then
+    cycle_fail=1
+  fi
+
+  if ! validate_status_word "current_status" "$first_current"; then
+    cycle_fail=1
+  fi
+
+  for read_idx in $(seq 2 "$READ_COUNT"); do
+    sleep_ms "$READ_DELAY_MS"
+    if ! sample="$(read_mailboxes_once "${cycle_id}_r${read_idx}")"; then
+      cycle_fail=1
+      continue
+    fi
+
+    read -r current_hex boot_probe_hex clr_hex <<< "$sample"
+    if ! validate_status_word "boot_probe" "$boot_probe_hex"; then
+      cycle_fail=1
+    fi
+    if ! validate_status_word "clr_status" "$clr_hex"; then
+      cycle_fail=1
+    fi
+    if ! validate_status_word "current_status" "$current_hex"; then
+      cycle_fail=1
+    fi
+
+    if [[ "$boot_probe_hex" != "$first_boot" ]]; then
+      echo "ERROR: cycle $cycle_id sticky boot_probe changed: first=$first_boot now=$boot_probe_hex" >&2
+      cycle_fail=1
+    fi
+  done
+
+  if [[ "$cycle_fail" -eq 0 ]]; then
+    printf 'cycle %s: PASS boot_probe=%s clr=%s current=%s\n' "$cycle_id" "$first_boot" "$first_clr" "$first_current"
+  else
+    printf 'cycle %s: FAIL\n' "$cycle_id" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    [[ "$STOP_ON_FAIL" -eq 1 ]] && break
+  fi
+done
+
+printf '\nSummary: fails=%s/%s\n' "$FAIL_COUNT" "$CYCLES"
+
+if [[ "$FAIL_COUNT" -eq 0 ]]; then
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- add `CubleySmokeTier0` managed nanoFramework app as a firmware-first Tier-0/Tier-1 interop harness
- add `tests/tier0_mailbox_reliability_smoke.sh` reset-cycle reliability gate with sticky mailbox checks
- document harness and smoke workflow in diagnostics and test docs
- append bring-up evidence for a 20-cycle PASS run using the harness
- include project compile include fix for `DiagnosticsStatusWord.cs` in `DiSEqC_Control.nfproj`

## Validation
- `./toolchain/build-managed.sh build --project CubleySmokeTier0/CubleySmokeTier0.nfproj --deploy --swd --address 0x080C0000 --reset`
- `./software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh --cycles 20 --read-count 4 --stop-on-fail`
- result: `fails=0/20`, stable `boot_probe=0xD5F00111`

## Issue Link
Closes #46
Part of #14
