### PR TITLE
[Phase C] #48 Specify normative Tier-0/Tier-1 encoding semantics

### DIFF
--- a/docs/debug/DIAGNOSTICS_MAILBOX.md
+++ b/docs/debug/DIAGNOSTICS_MAILBOX.md
@@ -63,6 +63,9 @@ Managed startup now latches its bitmap via:
 
 Mailbox words are 32-bit packed values.
 
+For Tier-0/Tier-1 diagnostics, this section is normative and must stay aligned
+with `docs/software/INTEROP_CONTRACT_V1.md`.
+
 ### Status word format
 
 `0xD5SSRRDD`
@@ -81,6 +84,21 @@ Standard Phase A result decode:
 - `15`: `EXCEPTION`
 
 Any other `RR` value is invalid for Phase A check words and must be rejected by readers.
+
+### Normative stage usage (Tier-0/Tier-1)
+
+The stage byte is producer-owned, but the following ranges/values are the
+documented Tier-0/Tier-1 contract used by current smoke tooling:
+
+- `0xC0..0xCF`: managed smoke harness stages (for example `CubleySmokeTier0`)
+   - observed: `0xC0` start, `0xC1` Tier-0 checks, `0xC2` Tier-1 checks, `0xCF` final
+- `0xE0..0xEF`: managed startup probe progression
+   - observed: `0xE0` managed entry, `0xE1` W5500 probe, `0xE2` LNBH26 probe,
+      `0xE3` FRAM probe, `0xEF` aggregate status
+- `0xF0`: sticky boot-probe aggregate latch stage
+
+Unlisted stage values are reserved for future producers and must be treated as
+unknown stage (not unknown format) if magic/result decode is valid.
 
 Phase A detail-byte mapping (`DD`) for smoke checks:
 
@@ -109,6 +127,12 @@ readers apply the same rules and fail fast on invalid magic/result codes.
 
 Interpretation of opcode/code/detail is subsystem-specific.
 
+Normative reader rule for Tier-0/Tier-1:
+
+- validate top-byte family (`0xE?`) and preserve raw word
+- decode opcode/code/detail only when the opcode has a documented decoder path
+- do not fail parsing solely because an opcode is unknown
+
 ## Ownership Rules
 
 Use these rules to avoid clobber races and ambiguous traces:
@@ -118,6 +142,16 @@ Use these rules to avoid clobber races and ambiguous traces:
 3. Runtime breadcrumbs (LED/network/etc.) may write `g_cubley_diag_current_status`.
 4. Error paths write `g_cubley_diag_last_error`.
 5. Do not clear sticky slots from normal runtime code.
+
+### Reset behavior
+
+- `g_cubley_diag_boot_probe_status` is sticky within a boot session and is
+   expected to reset to `0` on reboot/power-cycle before first managed latch.
+- `g_cubley_diag_current_status` is transient and may change frequently.
+- `g_cubley_diag_clr_status` reflects CLR/startup progression for the current
+   boot session.
+- `g_cubley_diag_last_error` reflects latest producer error for the current
+   boot session.
 
 ## SWD Usage
 

--- a/docs/debug/DIAGNOSTICS_MAILBOX.md
+++ b/docs/debug/DIAGNOSTICS_MAILBOX.md
@@ -87,18 +87,26 @@ Any other `RR` value is invalid for Phase A check words and must be rejected by 
 
 ### Normative stage usage (Tier-0/Tier-1)
 
-The stage byte is producer-owned, but the following ranges/values are the
-documented Tier-0/Tier-1 contract used by current smoke tooling:
+The stage byte is producer-owned. Readers must interpret stage values in
+producer context, because stage ranges can overlap between producers.
 
-- `0xC0..0xCF`: managed smoke harness stages (for example `CubleySmokeTier0`)
-   - observed: `0xC0` start, `0xC1` Tier-0 checks, `0xC2` Tier-1 checks, `0xCF` final
-- `0xE0..0xEF`: managed startup probe progression
-   - observed: `0xE0` managed entry, `0xE1` W5500 probe, `0xE2` LNBH26 probe,
+- Managed smoke harness (`CubleySmokeTier0`) currently emits:
+   - `0xC0` start, `0xC1` Tier-0 checks, `0xC2` Tier-1 checks, `0xCF` final
+- Managed startup probe currently emits:
+   - `0xE0` managed entry, `0xE1` W5500 probe, `0xE2` LNBH26 probe,
       `0xE3` FRAM probe, `0xEF` aggregate status
-- `0xF0`: sticky boot-probe aggregate latch stage
+- CLR startup producer may emit additional stage values (including values in the
+   `0xC*`/`0xD*` region); do not assume those regions are exclusive to managed
+   harness producers.
+- `0xF0` is reserved for sticky boot-probe aggregate latch stage.
 
 Unlisted stage values are reserved for future producers and must be treated as
 unknown stage (not unknown format) if magic/result decode is valid.
+
+`DD` interpretation note:
+
+- For stage `0xF0`, `DD` is a hardware bitmap (`bit0=W5500 bit1=LNBH26 bit2=FRAM`).
+- For other documented Phase A check words, `DD` follows the component mapping below.
 
 Phase A detail-byte mapping (`DD`) for smoke checks:
 
@@ -120,7 +128,7 @@ readers apply the same rules and fail fast on invalid magic/result codes.
 
 `0xE?OOCCDD`
 
-- Top byte identifies producer family (`0xE1` or `0xE2` seen currently)
+- Top byte identifies producer family (`0xE0..0xEF`; `0xE1` and `0xE2` observed currently)
 - `OO`: operation/opcode
 - `CC`: code
 - `DD`: detail
@@ -129,7 +137,7 @@ Interpretation of opcode/code/detail is subsystem-specific.
 
 Normative reader rule for Tier-0/Tier-1:
 
-- validate top-byte family (`0xE?`) and preserve raw word
+- validate top-byte family range (`0xE0..0xEF`) and preserve raw word
 - decode opcode/code/detail only when the opcode has a documented decoder path
 - do not fail parsing solely because an opcode is unknown
 

--- a/docs/software/INTEROP_CONTRACT_V1.md
+++ b/docs/software/INTEROP_CONTRACT_V1.md
@@ -76,12 +76,12 @@ decoder table explicitly defines an opcode.
 - `BringupStatus.NativeGet()` reads transient current status.
 - `BringupStatus.NativeGetLastNativeError()` reads latest error slot.
 - `DiagnosticsMailbox.NativeTryLatchBootProbe(word)` is latch-once per boot:
-	first write succeeds (`true`), subsequent writes fail (`false`) and must not
-	overwrite the latched value.
+  first write succeeds (`true`), subsequent writes fail (`false`) and must not
+  overwrite the latched value.
 - `DiagnosticsMailbox.NativeGetBootProbe()` returns latched value or `0` before
-	first latch.
+  first latch.
 - Sticky latch lifetime is one boot session; device reset/power cycle clears it
-	by runtime reinitialization.
+  by runtime reinitialization.
 
 ## Slot Policy (v1.x)
 

--- a/docs/software/INTEROP_CONTRACT_V1.md
+++ b/docs/software/INTEROP_CONTRACT_V1.md
@@ -18,6 +18,71 @@ This document is the source of truth for method slot governance in v1.x.
 - Native methods checksum (v1 baseline): `0xC5EF91C9`
 - Native assembly version tuple: `{ 1, 0, 0, 0 }`
 
+## Normative Tier-0/Tier-1 Diagnostics Semantics (Phase C)
+
+This section is normative for Tier-0/Tier-1 diagnostics behavior consumed by
+bring-up tooling and smoke gates.
+
+### Tier Ownership
+
+- Tier-0 APIs: `BringupStatus.*`, `DiagnosticsMailbox.*`
+- Tier-1 APIs: `StatusLed.*`, `UsbCdcConsole.*`
+
+Tier-1 APIs must not overwrite Tier-0 sticky diagnostics slot
+(`g_cubley_diag_boot_probe_status`).
+
+### Status Word Encoding (Normative)
+
+Status words are encoded as:
+
+- `0xD5SSRRDD`
+
+Where:
+
+- `0xD5` = status magic (required)
+- `SS` = stage byte (producer-defined stage)
+- `RR` = result code
+- `DD` = detail byte
+
+Normative result codes for Tier-0/Tier-1 diagnostics readers:
+
+- `0` = `ENTER`
+- `1` = `PASS`
+- `2` = `WARN`
+- `14` = `FAIL`
+- `15` = `EXCEPTION`
+
+Any other result code is invalid for Tier-0/Tier-1 smoke interpretation.
+
+### Error Word Encoding (Normative)
+
+Error words are encoded as:
+
+- `0xE?OOCCDD`
+
+Where:
+
+- top byte `0xE?` identifies producer family
+- `OO` = operation/opcode
+- `CC` = code
+- `DD` = detail
+
+Tier-0/Tier-1 tooling must treat `OO/CC/DD` as producer-specific unless a
+decoder table explicitly defines an opcode.
+
+### Reset and Stickiness Rules (Normative)
+
+- `BringupStatus.NativeSet()` writes transient current status.
+- `BringupStatus.NativeGet()` reads transient current status.
+- `BringupStatus.NativeGetLastNativeError()` reads latest error slot.
+- `DiagnosticsMailbox.NativeTryLatchBootProbe(word)` is latch-once per boot:
+	first write succeeds (`true`), subsequent writes fail (`false`) and must not
+	overwrite the latched value.
+- `DiagnosticsMailbox.NativeGetBootProbe()` returns latched value or `0` before
+	first latch.
+- Sticky latch lifetime is one boot session; device reset/power cycle clears it
+	by runtime reinitialization.
+
 ## Slot Policy (v1.x)
 
 - Slots `0..33` are immutable in v1.x.


### PR DESCRIPTION
## Summary
- define normative Tier-0/Tier-1 diagnostics semantics in the interop contract
- specify canonical status encoding (`0xD5SSRRDD`) and normative result codes
- specify error encoding family (`0xE?OOCCDD`) and reader behavior for unknown opcodes
- document Tier ownership and sticky/reset behavior requirements
- align diagnostics mailbox runbook with the normative stage map and reset semantics

## Files
- `docs/software/INTEROP_CONTRACT_V1.md`
- `docs/debug/DIAGNOSTICS_MAILBOX.md`

## Why
Issue #48 requires unambiguous status/error encoding behavior and reset/sticky
semantics for Tier-0/Tier-1 APIs, aligned across docs and smoke interpretation.

## Issue Link
Closes #48
Part of #14
