### PR TITLE
[Phase C] #47 Harden Tier-1 StatusLed/UsbCdcConsole smoke behavior

### DIFF
--- a/docs/debug/BRINGUP_TEST_LOG.md
+++ b/docs/debug/BRINGUP_TEST_LOG.md
@@ -1203,3 +1203,10 @@ This file should be committed and checked on each build to prevent version drift
 - Command(s): ./toolchain/build-managed.sh build --project CubleySmokeTier0/CubleySmokeTier0.nfproj --deploy --swd --address 0x080C0000 --reset && /workspaces/diseqc_cntrl/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh --cycles 20 --read-count 4 --stop-on-fail
 - Artifact: build/CubleySmokeTier0/CubleySmokeTier0.bin
 - Conclusion: CubleySmokeTier0 completed Tier-0/Tier-1 interop harness run; Tier-0 reset-cycle smoke passed 20/20 with stable boot-probe latch 0xD5F00111.
+
+### 2026-06-08 15:34:36 UTC [PASS] [NON-BASELINE]
+- Git rev: 6cf4d23
+- Baseline: NO — deviates from cubley-base Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): ./toolchain/build-managed.sh build --project CubleySmokeTier0/CubleySmokeTier0.nfproj --deploy --swd --address 0x080C0000 --reset && /workspaces/diseqc_cntrl/software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh --cycles 10 --read-count 4 --stop-on-fail
+- Artifact: build/CubleySmokeTier0/CubleySmokeTier0.bin
+- Conclusion: Tier-1 hardening run PASS: repeated mixed-order StatusLed/UsbCdcConsole interop executed across 10 reset cycles with stable boot_probe latch (0xD5F00111) and no unresolved Tier-1 failures.

--- a/software/nanoFramework/CubleySmokeTier0/Program.cs
+++ b/software/nanoFramework/CubleySmokeTier0/Program.cs
@@ -122,6 +122,12 @@ namespace CubleySmokeTier0
 
                 for (int i = 0; i < 6; i++)
                 {
+                    uint bootProbeBeforeIter = DiagnosticsMailbox.NativeGetBootProbe();
+                    if (bootProbeBeforeIter != LatchWord)
+                    {
+                        tier1Pass = false;
+                    }
+
                     // Emit deterministic per-iteration breadcrumbs for SWD diagnosis.
                     BringupStatus.NativeSet(Compose((byte)(StageTier1IterationBase + i), ResultEnter, (byte)i));
 

--- a/software/nanoFramework/CubleySmokeTier0/Program.cs
+++ b/software/nanoFramework/CubleySmokeTier0/Program.cs
@@ -15,6 +15,7 @@ namespace CubleySmokeTier0
         private const byte StageTier0 = 0xC1;
         private const byte StageTier1 = 0xC2;
         private const byte StageFinal = 0xCF;
+        private const byte StageTier1IterationBase = 0xD0;
 
         private const uint LatchWord = 0xD5F00111;
         private const uint LatchOverwriteAttemptWord = 0xD5F00E22;
@@ -29,10 +30,12 @@ namespace CubleySmokeTier0
             //   Then attempt overwrite with LatchOverwriteAttemptWord (0xD5F00E22);
             //   expected second call=false and NativeGetBootProbe() unchanged (still LatchWord).
             // - StatusLed (Tier-1): NativeInit/NativeSetLow/NativePulse are invoked; expected
-            //   behavior is successful non-throwing execution.
+            //   behavior is successful non-throwing execution under repeated mixed-order calls.
             // - UsbCdcConsole (Tier-1): NativeIsEnabled/NativeReadByte(0)/NativeWrite(...)
-            //   are invoked; expected read result >= -1 (timeout is -1) and write >= 0 when USB
-            //   CDC is enabled.
+            //   are invoked repeatedly; expected read result >= -1 (timeout is -1) and
+            //   write >= 0 when USB CDC is enabled.
+            // - Tier-1 safety rule: Tier-1 calls must not clobber boot-probe sticky latch;
+            //   NativeGetBootProbe() must remain equal to LatchWord before/after each Tier-1 iteration.
             byte detail = 0;
             bool pass = true;
 
@@ -96,7 +99,7 @@ namespace CubleySmokeTier0
 
             try
             {
-                // Tier-1 smoke: LED and USB console interop should execute without exceptions.
+                // Tier-1 smoke: repeated mixed-order LED/USB calls with sticky-slot preservation checks.
                 bool tier1Pass = true;
                 BringupStatus.NativeSet(Compose(StageTier1, ResultEnter, detail));
 
@@ -105,27 +108,63 @@ namespace CubleySmokeTier0
                 StatusLed.NativePulse(1, 50);
                 detail |= 0x10;
 
-                bool usbEnabled = UsbCdcConsole.NativeIsEnabled();
-                int readByte = UsbCdcConsole.NativeReadByte(0);
-                int writeRc = usbEnabled ? UsbCdcConsole.NativeWrite("CubleySmokeTier0 ready\r\n") : 0;
+                uint bootProbeBeforeTier1 = DiagnosticsMailbox.NativeGetBootProbe();
+                if (bootProbeBeforeTier1 != LatchWord)
+                {
+                    tier1Pass = false;
+                }
 
-                // Read timeout (-1) is valid for immediate mode; only enforce minimal call success.
-                if (readByte >= -1)
+                bool usbEnabled = UsbCdcConsole.NativeIsEnabled();
+                if (usbEnabled)
                 {
                     detail |= 0x20;
                 }
-                else
+
+                for (int i = 0; i < 6; i++)
                 {
-                    tier1Pass = false;
+                    // Emit deterministic per-iteration breadcrumbs for SWD diagnosis.
+                    BringupStatus.NativeSet(Compose((byte)(StageTier1IterationBase + i), ResultEnter, (byte)i));
+
+                    if ((i % 2) == 0)
+                    {
+                        StatusLed.NativeSetHigh();
+                        int readByte = UsbCdcConsole.NativeReadByte(0);
+                        StatusLed.NativeSetLow();
+                        StatusLed.NativePulse(1, 20 + (i * 5));
+
+                        // Read timeout (-1) is valid for immediate mode; require bounded sentinel semantics.
+                        if (readByte < -1)
+                        {
+                            tier1Pass = false;
+                        }
+                    }
+                    else
+                    {
+                        int writeRc = usbEnabled ? UsbCdcConsole.NativeWrite("CubleySmokeTier0 iter " + i.ToString() + "\r\n") : 0;
+                        StatusLed.NativePulse(2, 15 + (i * 5));
+                        int readByte = UsbCdcConsole.NativeReadByte(0);
+
+                        if (readByte < -1)
+                        {
+                            tier1Pass = false;
+                        }
+
+                        if (usbEnabled && writeRc < 0)
+                        {
+                            tier1Pass = false;
+                        }
+                    }
+
+                    uint bootProbeAfterIter = DiagnosticsMailbox.NativeGetBootProbe();
+                    if (bootProbeAfterIter != LatchWord)
+                    {
+                        tier1Pass = false;
+                    }
                 }
 
-                if (!usbEnabled || writeRc >= 0)
+                if (tier1Pass)
                 {
                     detail |= 0x40;
-                }
-                else
-                {
-                    tier1Pass = false;
                 }
 
                 BringupStatus.NativeSet(Compose(StageTier1, tier1Pass ? ResultPass : ResultFail, detail));

--- a/software/nanoFramework/tests/README.md
+++ b/software/nanoFramework/tests/README.md
@@ -141,5 +141,6 @@ cd /workspaces/diseqc_cntrl
 Harness behaviors:
 
 - Tier-0: `BringupStatus` set/get round-trip and `DiagnosticsMailbox` latch-once checks.
-- Tier-1: `StatusLed` and `UsbCdcConsole` calls for non-throwing execution verification.
+- Tier-1: repeated mixed-order `StatusLed` and `UsbCdcConsole` calls for stable execution verification.
+- Tier-1 safety: verifies Tier-1 call sequences do not clobber sticky boot-probe latch.
 - Final marker: writes a deterministic status word so SWD readers can confirm run completion.


### PR DESCRIPTION
## Summary
- harden `CubleySmokeTier0` Tier-1 coverage with repeated mixed-order `StatusLed` and `UsbCdcConsole` call sequences
- add explicit sticky-slot safety checks ensuring Tier-1 calls do not clobber `DiagnosticsMailbox` boot-probe latch
- keep deterministic per-iteration status breadcrumbs for SWD diagnosis
- document Tier-1 hardening behavior in test docs
- append bring-up evidence for a 10-cycle PASS run

## Validation
- `./toolchain/build-managed.sh build --project CubleySmokeTier0/CubleySmokeTier0.nfproj --deploy --swd --address 0x080C0000 --reset`
- `./software/nanoFramework/tests/tier0_mailbox_reliability_smoke.sh --cycles 10 --read-count 4 --stop-on-fail`
- result: `fails=0/10`, stable `boot_probe=0xD5F00111`

## Issue Link
Closes #47
Part of #14
