### PR TITLE
Ignore local agent configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vscode/*
 !.vscode/tasks.json
+.agents/
+.claude/settings.local.json
 .debug/
 .worktrees/
 


### PR DESCRIPTION
## Summary
- ignore the local vendored agent toolkit
- ignore machine-specific Claude permissions while leaving shared Claude configuration trackable

## Validation
- verified both current paths with `git check-ignore`
- verified `.claude/shared.md` remains trackable