### PR TITLE
Persist Bash history in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,7 +68,10 @@
 	// Uncomment to connect as a non-root user. See https: //aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"containerEnv": {
-		"SSH_AUTH_SOCK": "/tmp/ssh-agent.sock"
+		"SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
+		"HISTFILE": "/home/vscode/commandhistory/.bash_history",
+		"HISTSIZE": "10000",
+		"HISTFILESIZE": "20000"
 	}
 
 }

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -7,6 +7,29 @@ echo "Setting up environment..."
 
 #pip install -r requirements.txt
 
+# Persistent Bash history
+sudo touch /home/vscode/commandhistory/.bash_history
+sudo chown "$(id -u):$(id -g)" \
+	/home/vscode/commandhistory \
+	/home/vscode/commandhistory/.bash_history
+chmod 600 /home/vscode/commandhistory/.bash_history
+
+if ! grep -q "### devcontainer persistent bash history ###" ~/.bashrc; then
+cat >> ~/.bashrc <<'EOF'
+### devcontainer persistent bash history ###
+export HISTFILE=/home/vscode/commandhistory/.bash_history
+export HISTSIZE=10000
+export HISTFILESIZE=20000
+shopt -s histappend
+case ";${PROMPT_COMMAND:-};" in
+	*";history -a; history -n;"*) ;;
+	*) PROMPT_COMMAND="history -a; history -n${PROMPT_COMMAND:+; ${PROMPT_COMMAND}}" ;;
+esac
+### end devcontainer persistent bash history ###
+
+EOF
+fi
+
 # Git prompt
 if ! grep -q "### devcontainer git prompt ###" ~/.bashrc; then
 cat >> ~/.bashrc <<'EOF'


### PR DESCRIPTION
## Summary
- store Bash history in the existing persistent `nano-bashhistory` volume
- repair history directory and file ownership during container setup
- append and synchronize history across concurrent interactive terminals
- retain up to 20,000 persisted commands

## Validation
- `devcontainer.json` parses as JSONC
- `postcreate.sh` passes `bash -n`
- setup is idempotent and creates a writable `0600` history file
- fresh interactive Bash sessions load the persistent history path, size limits, `histappend`, and incremental flush hook
- `git diff --check` passes
