### PR TITLE
Fix LNB high-band continuous tone state

### DIFF
--- a/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/diseqc_transmitter.cpp
+++ b/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/diseqc_transmitter.cpp
@@ -290,3 +290,38 @@ diseqc_tx_status_t diseqc_set_tone(uint32_t frequencyHz, uint32_t dutyPercent, b
     diseqc_release();
     return status;
 }
+
+diseqc_tx_status_t diseqc_set_envelope_idle(bool high)
+{
+    if (!diseqc_try_claim())
+    {
+        return DISEQC_TX_BUSY;
+    }
+
+    if (PWMD4.state == PWM_READY)
+    {
+        if (PWMD4.config != &g_diseqc_pwm_config)
+        {
+            diseqc_release();
+            return DISEQC_TX_CARRIER_UNAVAILABLE;
+        }
+
+        pwmDisableChannel(&PWMD4, DISEQC_TIM4_CHANNEL);
+        pwmStop(&PWMD4);
+    }
+    else if (PWMD4.state != PWM_STOP)
+    {
+        diseqc_release();
+        return DISEQC_TX_CARRIER_UNAVAILABLE;
+    }
+
+    // In LNBH26 internal-generator mode (EXTM=0, TEN=1), DSQIN is an
+    // envelope gate. High requests continuous 22 kHz; low suppresses it.
+    // Program the output latch before changing from the timer alternate
+    // function so the LNB never sees an unintended gate pulse.
+    palWritePad(GPIOD, DISEQC_CARRIER_PIN, high ? PAL_HIGH : PAL_LOW);
+    palSetPadMode(GPIOD, DISEQC_CARRIER_PIN, PAL_MODE_OUTPUT_PUSHPULL);
+
+    diseqc_release();
+    return DISEQC_TX_OK;
+}

--- a/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/diseqc_transmitter.h
+++ b/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/diseqc_transmitter.h
@@ -21,6 +21,7 @@ typedef enum
 
 diseqc_tx_status_t diseqc_transmit_frame(const uint8_t *frame, size_t length);
 diseqc_tx_status_t diseqc_set_tone(uint32_t frequencyHz, uint32_t dutyPercent, bool enabled);
+diseqc_tx_status_t diseqc_set_envelope_idle(bool high);
 
 #ifdef __cplusplus
 }

--- a/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_native.cpp
+++ b/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_native.cpp
@@ -1,4 +1,5 @@
 #include "lnbh26_native.h"
+#include "diseqc_transmitter.h"
 
 #include <string.h>
 
@@ -362,7 +363,22 @@ lnb_status_t lnb_set_polarization(lnb_handle_t *hlnb, lnb_polarization_t polariz
     return lnb_set_polarization_for_channel(hlnb, LNB_CHANNEL_A, polarization);
 }
 
-static lnb_status_t lnb_set_tone_for_channel_internal(lnb_handle_t *hlnb, lnb_channel_t channel, bool enable)
+static void lnb_sync_data2_shadow(lnb_handle_t *hlnb, uint8_t data2)
+{
+    hlnb->data2_reg = data2;
+    hlnb->tone_enabled[0] = (data2 & LNBH26_DATA2_TEN_A) != 0U;
+    hlnb->low_power_enabled[0] = (data2 & LNBH26_DATA2_LPM_A) != 0U;
+    hlnb->diseqc_input_mode[0] = (data2 & LNBH26_DATA2_EXTM_A) != 0U
+        ? LNB_DISEQC_INPUT_ENABLED
+        : LNB_DISEQC_INPUT_DISABLED;
+    hlnb->tone_enabled[1] = (data2 & LNBH26_DATA2_TEN_B) != 0U;
+    hlnb->low_power_enabled[1] = (data2 & LNBH26_DATA2_LPM_B) != 0U;
+    hlnb->diseqc_input_mode[1] = (data2 & LNBH26_DATA2_EXTM_B) != 0U
+        ? LNB_DISEQC_INPUT_ENABLED
+        : LNB_DISEQC_INPUT_DISABLED;
+}
+
+lnb_status_t lnb_set_band_for_channel(lnb_handle_t *hlnb, lnb_channel_t channel, lnb_band_t band)
 {
     if (hlnb == NULL || !g_lnb_initialized)
     {
@@ -375,30 +391,73 @@ static lnb_status_t lnb_set_tone_for_channel_internal(lnb_handle_t *hlnb, lnb_ch
         return LNB_ERROR_INVALID_PARAM;
     }
 
-    lnb_handle_t previous = *hlnb;
-    hlnb->tone_enabled[lnb_channel_to_index(channel)] = enable;
-    lnb_refresh_shadow_registers(hlnb);
-
-    lnb_status_t status = lnb_write_data_registers(hlnb);
-    if (status != LNB_OK)
-    {
-        *hlnb = previous;
-        return status;
-    }
-
-    g_lnb = *hlnb;
-    return LNB_OK;
-}
-
-lnb_status_t lnb_set_band_for_channel(lnb_handle_t *hlnb, lnb_channel_t channel, lnb_band_t band)
-{
     if (band != LNB_BAND_LOW && band != LNB_BAND_HIGH)
     {
         lnb_set_last_error(LNB_ERROR_INVALID_PARAM, (int32_t)band);
         return LNB_ERROR_INVALID_PARAM;
     }
 
-    return lnb_set_tone_for_channel_internal(hlnb, channel, band == LNB_BAND_HIGH);
+    const int index = lnb_channel_to_index(channel);
+    const bool highBand = band == LNB_BAND_HIGH;
+    lnb_handle_t previous = *hlnb;
+
+    if (channel == LNB_CHANNEL_A)
+    {
+        const diseqc_tx_status_t pinStatus = diseqc_set_envelope_idle(highBand);
+        if (pinStatus != DISEQC_TX_OK)
+        {
+            lnb_set_last_error(LNB_ERROR_HARDWARE, (int32_t)pinStatus);
+            return LNB_ERROR_HARDWARE;
+        }
+    }
+
+    // Band selection always establishes the LNBH26 internal-generator mode:
+    // EXTM=0, TEN=1 and DSQIN=high for high band; TEN=0 and DSQIN=low for low.
+    // DiSEqC transmission may subsequently select EXTM=1 while it owns PD12.
+    hlnb->tone_enabled[index] = highBand;
+    hlnb->diseqc_input_mode[index] = LNB_DISEQC_INPUT_DISABLED;
+    lnb_refresh_shadow_registers(hlnb);
+
+    lnb_status_t status = lnb_write_data_registers(hlnb);
+    if (status != LNB_OK)
+    {
+        *hlnb = previous;
+        if (channel == LNB_CHANNEL_A)
+        {
+            const bool previousInternalTone =
+                previous.tone_enabled[0] && previous.diseqc_input_mode[0] == LNB_DISEQC_INPUT_DISABLED;
+            (void)diseqc_set_envelope_idle(previousInternalTone);
+        }
+        return status;
+    }
+
+    uint8_t data2Readback = 0;
+    status = lnb_read_register(hlnb, (uint8_t)LNBH26_REGISTER_DATA2, &data2Readback);
+    if (status != LNB_OK)
+    {
+        g_lnb = *hlnb;
+        return status;
+    }
+
+    const uint8_t toneMask = channel == LNB_CHANNEL_A ? LNBH26_DATA2_TEN_A : LNBH26_DATA2_TEN_B;
+    const uint8_t extmMask = channel == LNB_CHANNEL_A ? LNBH26_DATA2_EXTM_A : LNBH26_DATA2_EXTM_B;
+    const uint8_t verifyMask = (uint8_t)(toneMask | extmMask);
+    if ((data2Readback & verifyMask) != (hlnb->data2_reg & verifyMask))
+    {
+        lnb_sync_data2_shadow(hlnb, data2Readback);
+        if (channel == LNB_CHANNEL_A)
+        {
+            const bool actualInternalTone =
+                (data2Readback & toneMask) != 0U && (data2Readback & extmMask) == 0U;
+            (void)diseqc_set_envelope_idle(actualInternalTone);
+        }
+        g_lnb = *hlnb;
+        lnb_set_last_error(LNB_ERROR_I2C, -117);
+        return LNB_ERROR_I2C;
+    }
+
+    g_lnb = *hlnb;
+    return LNB_OK;
 }
 
 lnb_status_t lnb_set_band(lnb_handle_t *hlnb, lnb_band_t band)

--- a/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_native.h
+++ b/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_native.h
@@ -52,6 +52,7 @@ typedef enum
     LNB_ERROR_INVALID_PARAM = 1,
     LNB_ERROR_NOT_INITIALIZED = 2,
     LNB_ERROR_I2C = 3,
+    LNB_ERROR_HARDWARE = 4,
 } lnb_status_t;
 
 typedef enum

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -677,6 +677,10 @@ namespace CubleyControl
             int resumeFrequencyHz = _diseqcCarrierFrequencyHz;
             int resumeDutyPercent = _diseqcCarrierDutyPercent;
             bool toneRestored = false;
+            bool lnbStateCaptured = false;
+            bool lnbStateRestored = false;
+            int resumeBand = (int)LNBH26.Band.Low;
+            int resumeDiseqcInputMode = LnbDiseqcInputDisabled;
 
             try
             {
@@ -686,22 +690,45 @@ namespace CubleyControl
                     return false;
                 }
 
-                // For this board, EXTM + TEN yields the external DiSEqC gating path.
-                if (LNBH26.NativeSetEnable(LnbChannelA, true) != (int)LNBH26.Status.Ok)
+                int d1;
+                int d2;
+                int d3;
+                int d4;
+                int readStateRc = ReadLnbDataRegistersSafe(out d1, out d2, out d3, out d4);
+                if (readStateRc != (int)LNBH26.Status.Ok)
                 {
-                    error = "lnb_enable_failed";
+                    error = "lnb_state_read_" + readStateRc.ToString();
+                    return false;
+                }
+
+                // Motor power must be explicit and remain available for the
+                // full movement, not just while the DiSEqC frame is sent.
+                if (!IsLnbChannelEnabled(LnbChannelA, d1))
+                {
+                    error = "lnb_disabled";
+                    return false;
+                }
+
+                resumeBand = IsToneEnabledForChannel(LnbChannelA, d2)
+                    ? (int)LNBH26.Band.High
+                    : (int)LNBH26.Band.Low;
+                resumeDiseqcInputMode = IsExtmEnabledForChannel(LnbChannelA, d2)
+                    ? LnbDiseqcInputEnabled
+                    : LnbDiseqcInputDisabled;
+                lnbStateCaptured = true;
+
+                // Band selection first establishes a valid internal-tone state
+                // and a high DSQIN idle. DiSEqC then takes ownership of PD12 and
+                // switches the LNBH26 to accept the external 22 kHz waveform.
+                if (LNBH26.NativeSetBandForChannel(LnbChannelA, (int)LNBH26.Band.High) != (int)LNBH26.Status.Ok)
+                {
+                    error = "lnb_ten_failed";
                     return false;
                 }
 
                 if (LNBH26.NativeSetDiseqcInputModeForChannel(LnbChannelA, LnbDiseqcInputEnabled) != (int)LNBH26.Status.Ok)
                 {
                     error = "lnb_extm_failed";
-                    return false;
-                }
-
-                if (LNBH26.NativeSetBandForChannel(LnbChannelA, (int)LNBH26.Band.High) != (int)LNBH26.Status.Ok)
-                {
-                    error = "lnb_ten_failed";
                     return false;
                 }
 
@@ -731,6 +758,13 @@ namespace CubleyControl
                     DelayMicroseconds(DiseqcQuietGapUs);
                 }
 
+                if (!TryRestoreDiseqcLnbState(resumeBand, resumeDiseqcInputMode, out error))
+                {
+                    return false;
+                }
+
+                lnbStateRestored = true;
+
                 if (resumeTone)
                 {
                     int restoreStatus = ZZDiseqcTransmitter.NativeSetTone(
@@ -756,18 +790,9 @@ namespace CubleyControl
             }
             finally
             {
-                if (resumeTone && !toneRestored)
-                {
-                    int restoreStatus = ZZDiseqcTransmitter.NativeSetTone(
-                        resumeFrequencyHz,
-                        resumeDutyPercent,
-                        true);
-                    if (restoreStatus != (int)ZZDiseqcTransmitter.Status.Ok)
-                    {
-                        _diseqcCarrierEnabled = false;
-                    }
-                }
-                else if (!resumeTone)
+                // Stop any failed/incomplete external transmission before
+                // restoring the GPIO idle level for the requested LNB band.
+                if (!lnbStateRestored)
                 {
                     ZZDiseqcTransmitter.NativeSetTone(
                         DiseqcDefaultFrequencyHz,
@@ -775,8 +800,61 @@ namespace CubleyControl
                         false);
                 }
 
+                if (lnbStateCaptured && !lnbStateRestored)
+                {
+                    string restoreError;
+                    if (TryRestoreDiseqcLnbState(resumeBand, resumeDiseqcInputMode, out restoreError))
+                    {
+                        lnbStateRestored = true;
+                    }
+                    else
+                    {
+                        WriteStructuredDebug(
+                            "DISEQC",
+                            "schema=1 sub=diseqc comp=control operation=restore_lnb" +
+                            " stat=error reason=" + SanitizeToken(restoreError) +
+                            " level=error");
+                    }
+                }
+
+                // External continuous tone must be enabled only after EXTM/TEN
+                // and the requested LNB state have been restored. Enabling it
+                // earlier would be undone when band restoration reclaims PD12.
+                if (resumeTone && !toneRestored)
+                {
+                    if (lnbStateRestored)
+                    {
+                        int restoreStatus = ZZDiseqcTransmitter.NativeSetTone(
+                            resumeFrequencyHz,
+                            resumeDutyPercent,
+                            true);
+                        if (restoreStatus != (int)ZZDiseqcTransmitter.Status.Ok)
+                        {
+                            _diseqcCarrierEnabled = false;
+                        }
+                    }
+                    else
+                    {
+                        _diseqcCarrierEnabled = false;
+                    }
+                }
+
                 _diseqcTxBusy = false;
             }
+        }
+
+        private static bool TryRestoreDiseqcLnbState(int band, int inputMode, out string error)
+        {
+            int bandRc = LNBH26.NativeSetBandForChannel(LnbChannelA, band);
+            int inputRc = LNBH26.NativeSetDiseqcInputModeForChannel(LnbChannelA, inputMode);
+            if (bandRc == (int)LNBH26.Status.Ok && inputRc == (int)LNBH26.Status.Ok)
+            {
+                error = string.Empty;
+                return true;
+            }
+
+            error = "lnb_restore_band_" + bandRc.ToString() + "_extm_" + inputRc.ToString();
+            return false;
         }
 
         private static void DelayMicroseconds(int microseconds)

--- a/software/nanoFramework/CubleyControl/Program.Commands.Lnb.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Lnb.cs
@@ -211,6 +211,15 @@ namespace CubleyControl
                 int rc = LNBH26.NativeSetBandForChannel(channel, band);
                 if (rc == (int)LNBH26.Status.Ok)
                 {
+                    if (channel == LnbChannelA)
+                    {
+                        // Native band selection takes ownership of PD12 and
+                        // establishes the LNBH26 internal continuous-tone mode.
+                        _diseqcCarrierEnabled = false;
+                        _diseqcCarrierFrequencyHz = 0;
+                        _diseqcCarrierDutyPercent = 0;
+                    }
+
                     WriteCommandResult(reqId, true, "ok", "lnb band", "channel=" + LnbChannelToSchemaName(channel) + " value=" + BandToText(band));
                 }
                 else
@@ -476,6 +485,11 @@ namespace CubleyControl
             if (status == (int)LNBH26.Status.IoError)
             {
                 return "io_error";
+            }
+
+            if (status == (int)LNBH26.Status.HardwareError)
+            {
+                return "hardware_error";
             }
 
             return "unknown";

--- a/software/nanoFramework/CubleyNative.Interop/CubleyInteropNative.cs
+++ b/software/nanoFramework/CubleyNative.Interop/CubleyInteropNative.cs
@@ -33,7 +33,7 @@ namespace Cubley.Interop
         public enum Voltage { V13 = 0, V18 = 1 }
         public enum Polarization { Vertical = 0, Horizontal = 1 }
         public enum Band { Low = 0, High = 1 }
-        public enum Status { Ok = 0, InvalidParam = 1, NotInitialized = 2, IoError = 3 }
+        public enum Status { Ok = 0, InvalidParam = 1, NotInitialized = 2, IoError = 3, HardwareError = 4 }
 
         public enum Register
         {


### PR DESCRIPTION
## Summary
- make native LNB band selection own the PD12/DSQIN-A idle state
- establish the complete LNBH26 internal continuous-tone invariant (`EXTM=0`, `TEN=1`, DSQIN high, `LPM=0`) for channel A high band
- verify DATA2 readback and propagate hardware-control failures
- restore LNB and DiSEqC state transactionally after frame transmission
- keep managed carrier bookkeeping synchronized with native ownership

## Root cause
`lnb a band h` set `TEN`, but disabling TIM4 PWM left the active-high PD12/DSQIN-A signal low. The LNBH26 could therefore report high-band configuration without producing the required continuous 22 kHz tone.

## Validation
- managed CubleyControl Debug build: PASS
- native CUBLEY_F407_0_5 firmware build: PASS
- CubleyNative interop guard: PASS
- CubleyNative checksum: `0A4353F9`
- nanoBooter and nanoCLR flashed and verified by byte-for-byte SWD readback: PASS
- managed deployment region preserved

## Interop note
Interop behavior change (2026-08-30): band selection may now return `HardwareError` when PD12/TIM4 ownership cannot be established. Method ordering and signatures are unchanged.