### PR TITLE
Harden LNB, MQTT, and DiSEqC control paths

### DIFF
--- a/docs/debug/BRINGUP_TEST_LOG.md
+++ b/docs/debug/BRINGUP_TEST_LOG.md
@@ -1685,3 +1685,34 @@ This file should be committed and checked on each build to prevent version drift
 - Artifact: docs/debug/artifacts/rf-interface-2026-08-27/20260828-scope-j8-diseqc-hardware-timing-fixed.png; docs/debug/artifacts/rf-interface-2026-08-27/20260828-scope-j8-diseqc-hardware-timing-fixed.analysis.json; docs/debug/artifacts/rf-interface-2026-08-27/20260828-scope-j8-diseqc-hardware-timing-fixed.metadata.json
 - Conclusion: TIM4/TIM6 native transmission fixes the recorded DiSEqC symbol-timing fault: all 33 complete analyzed symbols satisfy mark, space, and total-duration limits.
 - Note: Observed sequence matches the first 33 bits of E0 10 38 F0 with odd parity; three right-edge bits were excluded. Ones: mark 0.420-0.490 ms, space 1.010-1.070 ms, total 1.460-1.540 ms. Zeros: mark 0.930-1.010 ms, space 0.520-0.600 ms, total 1.460-1.570 ms. Carrier 22.107 kHz from 471 periods; screenshot 780.208 mVpp. Raw transfer returned 5,000,000 of 10,000,000 declared samples at 20 ns intervals; edge uncertainty approximately 10 us.
+
+### 2026-08-28 18:42:46 UTC [PASS]
+- Git rev: cb84aa8
+- Baseline: YES — matches cubley-base Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): git pull origin main --ff-only; ./software/nanoFramework/toolchain/build-CubleyControl.sh build --project CubleyControl/CubleyControl.nfproj --configuration Debug; interop-checksum.sh --check CubleyNative; ./firmware/build-flash-cubley.sh build; generated map/ELF layout validation; ./firmware/build-flash-cubley.sh flash --bootaddr 0x08000000 --clraddr 0x08010000 --deployaddr 0x080C0000 --deploysize 0x00040000 --reset; rebuild CubleyControl; deploy-CubleyControl.sh --reset; nanoff devicedetails
+- Artifact: firmware/nf-interpreter/build/nanoBooter.bin; firmware/nf-interpreter/build/nanoCLR.bin; software/nanoFramework/build/CubleyControl/CubleyControl_bundle_20260828-184102.bin
+- Conclusion: Merged main firmware rebuilt and verified at explicit generated addresses; CubleyControl rebuilt and redeployed successfully; target reports nanoCLR running on CUBLEY_F407_0_5 with CubleyControl and CubleyNative loaded.
+- Note: Interop guard PASS at checksum 0x0A4353F9. nanoBooter 34,156 bytes at 0x08000000 and nanoCLR 696,080 bytes at 0x08010000 both flashed and verified; deployment region 0x080C0000-0x08100000. nanoff version check warning was non-fatal. Optional SWD mailbox script is absent from the current tree, so mailbox verification was not performed.
+
+### 2026-08-29 17:17:23 UTC [PASS]
+- Git rev: cb84aa8
+- Baseline: YES — matches cubley-base Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): build-CubleyControl.sh Debug; firmware/build-flash-cubley.sh build; firmware/build-flash-cubley.sh flash --reset; nanoff devicedetails
+- Artifact: firmware/nf-interpreter/build/nanoBooter.bin; firmware/nf-interpreter/build/nanoCLR.bin; software/nanoFramework/build/CubleyControl/CubleyControl_bundle_20260829-171423.bin
+- Conclusion: Corrected LNB native firmware built, flashed, verified, and restarted; retained managed assemblies resolve against CubleyNative checksum 0x0A4353F9.
+- Note: LNB output behavior requires USB CDC validation; managed retry fix is built but intentionally not deployed outside the VS Code nanoFramework workflow.
+
+### 2026-08-29 19:08:43 UTC [PASS]
+- Git rev: cb84aa8
+- Baseline: YES — matches cubley-base Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): USB CDC: diseqc step east 10; diseqc step west 10
+- Artifact: none
+- Conclusion: On cubley-a02663, Astra 2 disappeared from the analyser after the east 10 command and returned after the west 10 command, confirming reversible DiSEqC motor movement.
+
+### 2026-08-30 15:16:29 UTC [PASS]
+- Git rev: 5869304
+- Baseline: YES — matches cubley-base Phase A baseline (see docs/debug/PHASE_A_BASELINE.md)
+- Command(s): ./firmware/build-flash-cubley.sh build; st-info --probe; ./firmware/build-flash-cubley.sh flash --bootaddr 0x08000000 --clraddr 0x08010000 --deployaddr 0x080C0000 --deploysize 0x00040000 --reset; st-flash read + cmp
+- Artifact: firmware/nf-interpreter/build/nanoBooter.bin; firmware/nf-interpreter/build/nanoCLR.bin; /tmp/cubley-nanobooter-readback.bin; /tmp/cubley-nanoclr-readback.bin
+- Conclusion: Built and flashed nanoBooter and nanoCLR; both SWD readbacks matched the build artifacts byte-for-byte.
+- Note: Deployment region was preserved; software reset used AIRCR because NRST is not connected. Runtime mailbox verification script is absent from this checkout.

--- a/docs/software/MQTT_API.md
+++ b/docs/software/MQTT_API.md
@@ -29,6 +29,11 @@ configuration commands.
 The broker receives a retained `online` message after connection. The configured
 last will is retained `offline` at QoS 1.
 
+LNB and DiSEqC execution does not perform socket I/O. Responses, events, and state
+updates are placed in a bounded queue and published only by the MQTT worker. A
+broker failure, blocked publish, or full publication queue can lose MQTT output,
+but cannot delay or change completion of a hardware command.
+
 ## Commands And Results
 
 Publish a command marked as MQTT-supported in

--- a/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_interop.cpp
+++ b/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_interop.cpp
@@ -59,7 +59,7 @@ HRESULT Library_cubley_interop_LNBH26_NativeSetEnable___STATIC__I4__I4__BOOLEAN(
     lnb_status_t status = (lnb_status_t)lnb_native_set_enable_for_channel(channel, enable ? 1 : 0);
 
     // 0xE3 C2 SS DD: LNB set-enable result, DD=DATA1 readback on success or low I2C detail on failure.
-    uint8_t detail = (uint8_t)(lnb_get_last_i2c_msg() & 0xFF);
+    uint8_t detail = (uint8_t)(lnb_native_get_last_error_detail() & 0xFF);
     if (status == LNB_OK)
     {
         detail = lnb_try_read_reg_or_detail((int32_t)LNBH26_REGISTER_DATA1, detail);

--- a/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_native.cpp
+++ b/firmware/targets-local/CUBLEY_F407_0_5/nanoCLR/lnbh26_native.cpp
@@ -259,6 +259,29 @@ lnb_status_t lnb_set_enable_for_channel(lnb_handle_t *hlnb, lnb_channel_t channe
         return status;
     }
 
+    uint8_t data1Readback = 0;
+    status = lnb_read_register(hlnb, (uint8_t)LNBH26_REGISTER_DATA1, &data1Readback);
+    if (status != LNB_OK)
+    {
+        g_lnb = *hlnb;
+        return status;
+    }
+
+    const uint8_t channelMask =
+        (channel == LNB_CHANNEL_A) ? LNBH26_DATA1_VSEL_A_MASK : LNBH26_DATA1_VSEL_B_MASK;
+    if ((data1Readback & channelMask) != (hlnb->data1_reg & channelMask))
+    {
+        // The I2C transaction completed but the device did not retain the
+        // requested output state. Keep software state aligned with hardware and
+        // report failure instead of returning a false successful enable.
+        hlnb->data1_reg = data1Readback;
+        hlnb->enabled[0] = (data1Readback & LNBH26_DATA1_VSEL_A_MASK) != 0;
+        hlnb->enabled[1] = (data1Readback & LNBH26_DATA1_VSEL_B_MASK) != 0;
+        g_lnb = *hlnb;
+        lnb_set_last_error(LNB_ERROR_I2C, -123);
+        return LNB_ERROR_I2C;
+    }
+
     g_lnb = *hlnb;
     return LNB_OK;
 }

--- a/software/nanoFramework/CubleyControl/Program.Commands.Lnb.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Lnb.cs
@@ -157,13 +157,31 @@ namespace CubleyControl
 
                 bool enable = field == "enable";
                 int rc = LNBH26.NativeSetEnable(channel, enable);
+                uint nativeDiagnostic = DiagMailbox.NativeGetLastNativeError();
+
+                WriteStructuredDebug(
+                    "LNB",
+                    "schema=1 sub=lnb comp=control operation=set_enable" +
+                    " stat=" + (rc == (int)LNBH26.Status.Ok ? "ok" : "error") +
+                    " channel=" + LnbChannelToSchemaName(channel) +
+                    " requested=" + (enable ? "on" : "off") +
+                    " rc=" + rc.ToString() +
+                    " native_diag=0x" + nativeDiagnostic.ToString("X8"));
+
                 if (rc == (int)LNBH26.Status.Ok)
                 {
                     WriteCommandResult(reqId, true, "ok", "lnb " + field, "channel=" + LnbChannelToSchemaName(channel) + " value=" + (enable ? "on" : "off"));
                 }
                 else
                 {
-                    WriteCommandResult(reqId, false, "hw_fault", "lnb " + field + " failed", "channel=" + LnbChannelToSchemaName(channel) + " rc=" + rc.ToString());
+                    WriteCommandResult(
+                        reqId,
+                        false,
+                        "hw_fault",
+                        "lnb " + field + " failed",
+                        "channel=" + LnbChannelToSchemaName(channel) +
+                        " rc=" + rc.ToString() +
+                        " native_diag=0x" + nativeDiagnostic.ToString("X8"));
                 }
 
                 return;
@@ -659,7 +677,13 @@ namespace CubleyControl
         {
             int rc = LNBH26Registers.NativeReadRegister((int)register, out value);
 
-            if (rc == (int)LNBH26.Status.IoError || rc == (int)LNBH26.Status.NotInitialized)
+            if (rc == (int)LNBH26.Status.IoError)
+            {
+                // NativeInit writes safe defaults, including disabling both outputs.
+                // A transient read failure must not erase an active LNB configuration.
+                rc = LNBH26Registers.NativeReadRegister((int)register, out value);
+            }
+            else if (rc == (int)LNBH26.Status.NotInitialized)
             {
                 _lnbInitAttempted = false;
                 if (EnsureLnbInitialized())
@@ -712,7 +736,13 @@ namespace CubleyControl
                     " detail=" + lastDetail.ToString());
             }
 
-            if (rc == (int)LNBH26.Status.IoError || rc == (int)LNBH26.Status.NotInitialized)
+            if (rc == (int)LNBH26.Status.IoError)
+            {
+                // Retry the non-mutating read. Reinitializing here would silently
+                // disable an output after an otherwise successful enable command.
+                rc = LNBH26.NativeReadStatusPair(out s1, out s2);
+            }
+            else if (rc == (int)LNBH26.Status.NotInitialized)
             {
                 _lnbInitAttempted = false;
                 if (EnsureLnbInitialized())

--- a/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
@@ -16,6 +16,7 @@ namespace CubleyControl
         private const int MqttCommandEnvelopeMaxLength = MqttCommandMaxLength + MqttCommandIdMaxLength + 1;
         private const int MqttDuplicateCacheSize = 8;
         private const int MqttCachedResponseLimit = 32;
+        private const int MqttPublishQueueCapacity = 64;
         private const string MqttAvailabilityOnline = "online";
         private const string MqttAvailabilityOffline = "offline";
         private static MqttClient _mqttClient;
@@ -36,10 +37,19 @@ namespace CubleyControl
         private static readonly string[] _mqttActiveResponses = new string[MqttCachedResponseLimit];
         private static readonly object _mqttCommandTransactionLock = new object();
         private static readonly object _mqttEventLock = new object();
+        private static readonly object _mqttPublishQueueLock = new object();
+        private static readonly string[] _mqttPublishTopics = new string[MqttPublishQueueCapacity];
+        private static readonly string[] _mqttPublishPayloads = new string[MqttPublishQueueCapacity];
+        private static readonly MqttQoSLevel[] _mqttPublishQosLevels = new MqttQoSLevel[MqttPublishQueueCapacity];
+        private static readonly bool[] _mqttPublishRetainFlags = new bool[MqttPublishQueueCapacity];
         private static int _mqttDuplicateCacheNext;
         private static int _mqttEventSequence;
         private static ushort _mqttActiveCommandId;
         private static int _mqttActiveResponseCount;
+        private static int _mqttPublishQueueHead;
+        private static int _mqttPublishQueueCount;
+        private static int _mqttPublishDropCount;
+        private static bool _mqttPublishAccepting;
 
         private static void MqttLoop()
         {
@@ -140,15 +150,21 @@ namespace CubleyControl
                 _mqttReconnectAttempts = 0;
                 _mqttLastError = string.Empty;
                 _mqttRuntimeState = "connected";
+                SetMqttPublishAccepting(true);
                 WriteStructuredDebug(
                     "MQTT",
                     "schema=1 sub=mqtt comp=connection operation=connect stat=ok" +
                     " broker=" + SanitizeToken(configuration.Broker) +
                     " port=" + configuration.Port.ToString());
 
-                PublishLine(availabilityTopic, MqttAvailabilityOnline, MqttQoSLevel.AtLeastOnce, true);
+                QueueMqttPublication(availabilityTopic, MqttAvailabilityOnline, MqttQoSLevel.AtLeastOnce, true);
                 PublishMqttState();
                 PublishMqttDiseqcState();
+                if (!DrainMqttPublicationQueue(_mqttClient))
+                {
+                    return;
+                }
+
                 _mqttRuntimeState = "subscribing";
                 ushort subscriptionMessageId = _mqttClient.Subscribe(
                     new string[] { _mqttCommandTopic },
@@ -163,7 +179,12 @@ namespace CubleyControl
                     revision == _mqttConfigurationRevision &&
                     _mqttRuntimeState != "error")
                 {
-                    Thread.Sleep(500);
+                    if (!DrainMqttPublicationQueue(_mqttClient))
+                    {
+                        break;
+                    }
+
+                    Thread.Sleep(100);
                 }
 
                 if (_mqttClient.IsConnected)
@@ -173,6 +194,7 @@ namespace CubleyControl
             }
             finally
             {
+                SetMqttPublishAccepting(false);
                 MqttClient client = _mqttClient;
                 _mqttClient = null;
                 _mqttCommandTopic = string.Empty;
@@ -434,7 +456,7 @@ namespace CubleyControl
                 " transport=mqtt topic=" + _mqttResponseTopic +
                 " duplicate=" + (duplicate ? "1" : "0") +
                 " payload=" + SanitizeToken(payload));
-            PublishLine(_mqttResponseTopic, payload, MqttQoSLevel.AtLeastOnce, false);
+            QueueMqttPublication(_mqttResponseTopic, payload, MqttQoSLevel.AtLeastOnce, false);
         }
 
         private static void PublishMqttLnbFaultTransition(bool active, string source)
@@ -477,12 +499,7 @@ namespace CubleyControl
         private static void PublishMqttLnbEvent(string payload)
         {
             WriteStructuredDebug("LNB", payload);
-            if (_mqttClient == null || !_mqttClient.IsConnected || string.IsNullOrEmpty(_mqttEventTopic))
-            {
-                return;
-            }
-
-            PublishLine(_mqttEventTopic, payload, MqttQoSLevel.AtLeastOnce, false);
+            QueueMqttPublication(_mqttEventTopic, payload, MqttQoSLevel.AtLeastOnce, false);
         }
 
         private static void PublishMqttState()
@@ -517,12 +534,7 @@ namespace CubleyControl
             }
 
             WriteStructuredDebug("LNB", payload);
-            if (_mqttClient == null || !_mqttClient.IsConnected || string.IsNullOrEmpty(_mqttStateTopic))
-            {
-                return;
-            }
-
-            PublishLine(_mqttStateTopic, payload, MqttQoSLevel.AtLeastOnce, true);
+            QueueMqttPublication(_mqttStateTopic, payload, MqttQoSLevel.AtLeastOnce, true);
         }
 
         private static void PublishMqttDiseqcMotionTransition(string transition)
@@ -545,10 +557,7 @@ namespace CubleyControl
                 " completion=" + completionSource;
 
             WriteStructuredDebug("DISEQC", payload);
-            if (_mqttClient != null && _mqttClient.IsConnected && !string.IsNullOrEmpty(_mqttDiseqcEventTopic))
-            {
-                PublishLine(_mqttDiseqcEventTopic, payload, MqttQoSLevel.AtLeastOnce, false);
-            }
+            QueueMqttPublication(_mqttDiseqcEventTopic, payload, MqttQoSLevel.AtLeastOnce, false);
 
             PublishMqttDiseqcState();
         }
@@ -572,16 +581,12 @@ namespace CubleyControl
                 " timeout_ms=" + _diseqcMotionTimeoutMs.ToString();
 
             WriteStructuredDebug("DISEQC", payload);
-            if (_mqttClient == null || !_mqttClient.IsConnected || string.IsNullOrEmpty(_mqttDiseqcStateTopic))
-            {
-                return;
-            }
-
-            PublishLine(_mqttDiseqcStateTopic, payload, MqttQoSLevel.AtLeastOnce, true);
+            QueueMqttPublication(_mqttDiseqcStateTopic, payload, MqttQoSLevel.AtLeastOnce, true);
         }
 
         private static void OnMqttConnectionClosed(object sender, EventArgs e)
         {
+            SetMqttPublishAccepting(false);
             _mqttRuntimeState = "disconnected";
             WriteStructuredDebug(
                 "MQTT",
@@ -648,30 +653,129 @@ namespace CubleyControl
             return new string(new char[] { digits[(value >> 4) & 0x0F], digits[value & 0x0F] });
         }
 
-        private static void PublishLine(string topic, string payload, MqttQoSLevel qosLevel, bool retain)
+        private static void QueueMqttPublication(string topic, string payload, MqttQoSLevel qosLevel, bool retain)
         {
-            if (_mqttClient == null || !_mqttClient.IsConnected)
+            bool dropped = false;
+            lock (_mqttPublishQueueLock)
             {
-                return;
+                if (!_mqttPublishAccepting || string.IsNullOrEmpty(topic))
+                {
+                    return;
+                }
+
+                if (_mqttPublishQueueCount >= MqttPublishQueueCapacity)
+                {
+                    _mqttPublishDropCount++;
+                    dropped = true;
+                }
+                else
+                {
+                    int queueIndex = (_mqttPublishQueueHead + _mqttPublishQueueCount) % MqttPublishQueueCapacity;
+                    _mqttPublishTopics[queueIndex] = topic;
+                    _mqttPublishPayloads[queueIndex] = payload;
+                    _mqttPublishQosLevels[queueIndex] = qosLevel;
+                    _mqttPublishRetainFlags[queueIndex] = retain;
+                    _mqttPublishQueueCount++;
+                }
             }
 
-            try
-            {
-                _mqttClient.Publish(
-                    topic,
-                    AsciiStringToBytes(payload),
-                    null,
-                    null,
-                    qosLevel,
-                    retain);
-            }
-            catch (Exception ex)
+            if (dropped)
             {
                 WriteStructuredDebug(
                     "MQTT",
-                    "schema=1 sub=mqtt comp=publish operation=send stat=error" +
-                    " code=publish_exception topic=" + topic +
-                    " detail=" + SanitizeToken(ex.Message));
+                    "schema=1 sub=mqtt comp=publish operation=queue stat=error" +
+                    " code=queue_full dropped=" + _mqttPublishDropCount.ToString());
+            }
+        }
+
+        private static bool DrainMqttPublicationQueue(MqttClient client)
+        {
+            while (true)
+            {
+                string topic;
+                string payload;
+                MqttQoSLevel qosLevel;
+                bool retain;
+                if (!TryDequeueMqttPublication(out topic, out payload, out qosLevel, out retain))
+                {
+                    return true;
+                }
+
+                try
+                {
+                    client.Publish(
+                        topic,
+                        AsciiStringToBytes(payload),
+                        null,
+                        null,
+                        qosLevel,
+                        retain);
+                }
+                catch (Exception ex)
+                {
+                    _mqttLastError = "publish_exception";
+                    _mqttRuntimeState = "error";
+                    WriteStructuredDebug(
+                        "MQTT",
+                        "schema=1 sub=mqtt comp=publish operation=send stat=error" +
+                        " code=publish_exception topic=" + topic +
+                        " detail=" + SanitizeToken(ex.Message));
+                    SetMqttPublishAccepting(false);
+                    return false;
+                }
+            }
+        }
+
+        private static bool TryDequeueMqttPublication(
+            out string topic,
+            out string payload,
+            out MqttQoSLevel qosLevel,
+            out bool retain)
+        {
+            lock (_mqttPublishQueueLock)
+            {
+                if (_mqttPublishQueueCount == 0)
+                {
+                    topic = null;
+                    payload = null;
+                    qosLevel = MqttQoSLevel.AtMostOnce;
+                    retain = false;
+                    return false;
+                }
+
+                int queueIndex = _mqttPublishQueueHead;
+                topic = _mqttPublishTopics[queueIndex];
+                payload = _mqttPublishPayloads[queueIndex];
+                qosLevel = _mqttPublishQosLevels[queueIndex];
+                retain = _mqttPublishRetainFlags[queueIndex];
+                _mqttPublishTopics[queueIndex] = null;
+                _mqttPublishPayloads[queueIndex] = null;
+                _mqttPublishRetainFlags[queueIndex] = false;
+                _mqttPublishQueueHead = (_mqttPublishQueueHead + 1) % MqttPublishQueueCapacity;
+                _mqttPublishQueueCount--;
+                return true;
+            }
+        }
+
+        private static void SetMqttPublishAccepting(bool accepting)
+        {
+            lock (_mqttPublishQueueLock)
+            {
+                _mqttPublishAccepting = accepting;
+                if (accepting)
+                {
+                    return;
+                }
+
+                for (int index = 0; index < MqttPublishQueueCapacity; index++)
+                {
+                    _mqttPublishTopics[index] = null;
+                    _mqttPublishPayloads[index] = null;
+                    _mqttPublishRetainFlags[index] = false;
+                }
+
+                _mqttPublishQueueHead = 0;
+                _mqttPublishQueueCount = 0;
             }
         }
 

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcCommandBuilder.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcCommandBuilder.cs
@@ -159,7 +159,10 @@ namespace Cubley.Diseqc
 
         private static byte NormalizeSteps(byte steps)
         {
-            return steps == 0 ? (byte)1 : steps;
+            // DiSEqC positioner step counts are negative 8-bit values: FF is
+            // one step, FE is two steps, ... and 80 is 128 steps.
+            int normalizedSteps = steps == 0 ? 1 : steps;
+            return (byte)(256 - normalizedSteps);
         }
     }
 }


### PR DESCRIPTION
## Summary
- verify LNBH26 DATA1 after output enable changes and report states the device did not retain
- retry non-mutating LNB reads without reinitializing and disabling active outputs
- queue MQTT publications so broker latency/failure cannot block LNB or DiSEqC hardware command completion
- encode DiSEqC positioner step counts using the protocol's negative 8-bit representation
- record recent firmware, RF, motor, and SWD validation results

## Validation
- CubleyControl Debug managed build: PASS
- CubleyNative interop checksum: `0A4353F9`
- CubleyNative interop guard: PASS
- CUBLEY_F407_0_5 native firmware build: PASS
- nanoBooter: 34,156 bytes
- nanoCLR: 696,608 bytes
- no flash or deployment performed for this PR validation run

## Notes
- no interop method ordering or signature changes
- transponder architecture, PB7/FRAM test plan, RF interface test plan, and nonfree STEP assets are intentionally excluded
- no focused automated test project exists for the affected command builder or MQTT paths