### PR TITLE
Use REST for control and MQTT for state

### DIFF
--- a/docs/software/DEVICE_API_V2.md
+++ b/docs/software/DEVICE_API_V2.md
@@ -1,0 +1,287 @@
+# Device API v2 — JSON Command Envelope And Positioner Jobs
+
+Status: **draft contract**, implemented on the device but not yet exercised on
+hardware. Supersedes the positional MQTT envelope described in
+[MQTT_API.md](MQTT_API.md) for the `command` and `response` topics, and adds a
+positioner job resource to `event/diseqc` and `state/diseqc`.
+
+## Why this exists
+
+The v1 MQTT envelope was `<decimal id> <console command line>` — the human
+console grammar used as a wire format, capped at 64 bytes, with a 16-bit
+requester-assigned ID as its first token. Two problems followed from that:
+
+1. The machine API and the operator CLI shared one grammar, so neither could
+   change without breaking the other.
+2. Long-running positioner movement had no representation. `diseqc goto 12`
+   returned `OK` when the *frame was transmitted*, and the only ways to learn
+   that motion had ended were a watchdog deadline or the client telling the
+   device it had finished (`diseqc complete <motion_id>`) — an inversion of
+   who knows what.
+
+v2 separates the two layers. The USB CDC console keeps its Cisco IOS-style
+grammar unchanged and remains the primary operator and bring-up interface. The
+network transport carries JSON. Both drive the same hardware paths.
+
+## Layering
+
+```
+USB CDC  ──  IOS-style CLI  ──┐
+                              ├──>  operation  ──>  DiSEqC / LNB hardware
+MQTT     ──  JSON envelope  ──┘
+```
+
+Nothing in this document changes the console. An operator types
+`diseqc goto 12` at the serial prompt exactly as before.
+
+## Transport
+
+Unchanged from v1: MQTT 3.1.1, no TLS, QoS 1, topic root `<prefix>/<hostname>`.
+
+| Direction | Topic | Payload | Retained |
+|---|---|---|---|
+| Command to device | `<root>/command` | v2 command object | Must be false |
+| Response from device | `<root>/response` | v2 response object, **one per command** | No |
+| Positioner job transition | `<root>/event/diseqc` | v2 event object | No |
+| Current positioner state | `<root>/state/diseqc` | v2 state object | Yes |
+| LNB transition / state | `<root>/event/lnb`, `<root>/state/lnb` | unchanged schema-1 key/value text | see MQTT_API.md |
+| Availability | `<root>/availability` | `online` / `offline` | Yes |
+
+LNB event and state topics are **not** migrated by this change and keep their
+schema-1 key/value form.
+
+### Payload constraints
+
+The device parses a deliberately small JSON subset. This is a hard contract,
+not an implementation detail — it is what makes the parser bounded on a
+192 KB-RAM target.
+
+- The payload MUST be a single JSON object.
+- Values MUST be string, integer, boolean, or null. **No nested objects, no
+  arrays, no floating point.** A fractional or exponent number is rejected.
+- At most 12 members; keys at most 24 characters; string values at most 128
+  characters.
+- The whole payload MUST be at most 256 bytes of ASCII.
+- Unknown members are rejected rather than ignored, so a typo fails loudly
+  instead of silently doing the wrong thing to a motor.
+
+Byte strings (raw DiSEqC frames) are carried as uppercase hex strings rather
+than arrays, e.g. `"frame":"E01038F0"`.
+
+## Command envelope
+
+```json
+{"v":2,"id":"01J8ZK4M7Q","op":"positioner.goto","position":12}
+```
+
+| Member | Type | Required | Meaning |
+|---|---|---|---|
+| `v` | int | no (default 2) | Contract version. Only `2` is accepted. |
+| `id` | string | **yes** | Requester-assigned idempotency key, 1–32 chars of `A-Za-z0-9._:-`. |
+| `op` | string | **yes** | Operation name, 1–40 chars of `a-z0-9._`. |
+| … | | | Operation-specific parameters. |
+
+### `id` is an idempotency key, not a correlation tag
+
+QoS 1 is at-least-once: the broker may redeliver a command, and a redelivered
+`positioner.step` is byte-identical to a genuine second one. Only the publisher
+knows which it is, so the publisher labels it. This is the same role
+`Idempotency-Key` plays in an HTTP API, and it would still be required if this
+were REST.
+
+It is not carried in MQTT 5 `Correlation Data` because the nanoFramework M2Mqtt
+client decodes that property off the wire and then discards it before raising
+`MqttMsgPublishReceived` — `MqttMsgPublishEventArgs` exposes only topic,
+payload, dup flag, QoS and retain. Until that is fixed upstream, an inbound
+correlation token has to live in the payload regardless of protocol version.
+
+### Deduplication
+
+The device remembers the 8 most recent `{id, raw payload, response}`
+transactions for **120 seconds**.
+
+- Same `id`, byte-identical payload, within the window → the original response
+  is republished verbatim with an added `"replayed":true` member, and the
+  command is **not** executed again. `ok` and `code` stay as they originally
+  were, so a replay is never mistaken for a fresh execution.
+- Same `id`, different payload, within the window → `id_conflict`, nothing
+  executes.
+- Any `id` older than the window, or evicted by the 8-entry ring → treated as
+  new and executed.
+
+The TTL is what makes this predictable: under the v1 slot-count-only scheme,
+whether a reused ID replayed or conflicted depended on how many unrelated
+commands had happened since. Requesters should still use unique IDs (a ULID or
+UUID is ideal, and 32 chars is enough for either).
+
+## Response envelope
+
+Exactly one response is published per accepted command.
+
+```json
+{"v":2,"id":"01J8ZK4M7Q","ok":true,"code":"accepted","job":7,"ts_ms":41231}
+```
+
+| Member | Type | Always | Meaning |
+|---|---|---|---|
+| `v` | int | yes | Always `2`. |
+| `id` | string | yes | Echo of the command `id`, or `"?"` if the envelope was unparseable. |
+| `ok` | bool | yes | Whether the command was accepted and completed. |
+| `code` | string | yes | Machine-readable outcome, see below. |
+| `ts_ms` | int | yes | Device uptime in milliseconds when the response was formed. Monotonic within a boot; **not** wall clock, and it restarts at reboot. |
+| `msg` | string | on failure | Short human-readable detail. |
+| `job` | int | positioner ops | Job the command started, or the job that blocked it. |
+| `data` | object | structured ops | Operation result. Outbound only, so unlike a command payload it may contain nested objects. |
+| `lines` | string | bridged ops | Console output, `\n`-separated. See *Bridged operations*. |
+
+### Result codes
+
+| `code` | `ok` | Meaning |
+|---|---|---|
+| `ok` | true | Completed. Terminal, nothing further happens. |
+| `accepted` | true | A job was started. Motion continues after this response. |
+| `validation_error` | false | Malformed envelope, unknown member, bad parameter. |
+| `unsupported` | false | Unknown `op`, or an op not permitted on this transport. |
+| `busy` | false | A positioner job is already running; `job` names it. |
+| `hw_fault` | false | Hardware or transmission failure. |
+| `id_conflict` | false | `id` reused within the dedup window with a different payload. |
+| `not_found` | false | Referenced job is unknown or has been evicted. |
+
+## Positioner job model
+
+A job is created by any command that starts motion, and it is the only thing
+that represents "the dish is moving".
+
+### States
+
+| State | Terminal | Meaning |
+|---|---|---|
+| `running` | no | Frame transmitted; the positioner is presumed moving. |
+| `halted` | yes | `positioner.halt` stopped it, or a `stop` was issued at the console. |
+| `timeout` | yes | The motion watchdog expired and the device transmitted Halt. |
+| `timeout_halt_failed` | yes | The watchdog expired but the Halt transmission failed. **The positioner may still be moving.** |
+| `released` | yes | A client asserted that motion finished. |
+
+**There is deliberately no `succeeded` state.** A DiSEqC 1.2 positioner returns
+no arrival indication, so the device cannot know the dish reached its target —
+it only knows what it transmitted and how much time has passed. `released`
+records a *client's claim* of arrival, not a device observation. Any consumer
+that needs true arrival must establish it out of band (signal lock, for
+example) and then call `positioner.release`.
+
+`timeout` is the normal terminal state for `positioner.drive`, which has no
+intrinsic duration, and the fallback for `goto` and `step`.
+
+### Lifecycle
+
+```
+positioner.goto/step/drive ──> running ──┬── positioner.halt ────> halted
+                                         ├── watchdog expiry ────> timeout
+                                         │                         timeout_halt_failed
+                                         └── positioner.release ─> released
+```
+
+Only one job runs at a time. A motion command while a job is `running` fails
+with `busy` and names the active job; it does not queue. The device retains the
+4 most recent job records, so a terminal job stays queryable via
+`positioner.job` until evicted.
+
+### Job object
+
+```json
+{"job":7,"op":"goto","state":"running","remaining_ms":83400,"timeout_ms":90000,"detail":""}
+```
+
+`remaining_ms` is 0 for terminal states. `detail` carries a failure reason for
+`timeout_halt_failed` and is empty otherwise.
+
+## Operations
+
+### Positioner — structured
+
+| `op` | Parameters | Response |
+|---|---|---|
+| `positioner.goto` | `position` int 0–255 | `accepted` + `job`, or `busy` |
+| `positioner.step` | `direction` `"east"`\|`"west"`, `count` int 1–128 | `accepted` + `job`, or `busy` |
+| `positioner.drive` | `direction` `"east"`\|`"west"` | `accepted` + `job`, or `busy` |
+| `positioner.halt` | — | `ok`; terminates the active job as `halted` |
+| `positioner.release` | `job` int | `ok`; terminates that job as `released` |
+| `positioner.job` | `job` int | `ok` + `data` = job object, or `not_found` |
+| `positioner.show` | — | `ok` + `data` = current state object |
+
+`positioner.release` checks the job id, so a late release for a superseded job
+is rejected rather than ending a newer movement.
+
+### Bridged operations
+
+These ops are accepted on the JSON transport but are still executed by the
+legacy console tokenizer, and return console text in `lines` rather than a
+structured `data` object:
+
+| `op` | Parameters | Console equivalent |
+|---|---|---|
+| `system.status` | — | `status` |
+| `system.version` | — | `version` |
+| `system.capabilities` | — | `capabilities` |
+| `lnb.show` | `channel` `"a"`\|`"b"` (optional) | `show lnb [a\|b]` |
+| `lnb.enable` / `lnb.disable` | `channel` | `lnb <ch> enable\|disable` |
+| `lnb.polarization` | `channel`, `value` | `lnb <ch> polarization <value>` |
+| `lnb.band` | `channel`, `value` | `lnb <ch> band <value>` |
+| `diseqc.tx` | `frame` hex string, 1–6 bytes | `diseqc tx <bytes>` |
+| `diseqc.preset` | `value` | `diseqc preset <value>` |
+| `diseqc.tone` | `value` `"on"`\|`"off"` | `diseqc tone <value>` |
+| `diseqc.show` | — | `show diseqc` |
+
+The bridge is a migration stage, not the destination. It exists so the wire
+contract could be finalised in one change without rewriting every handler
+untested. Moving an op from `lines` to `data` is a **breaking change and
+requires a contract version bump** — v2 freezes the shapes above.
+
+Configuration commands remain unavailable on MQTT, as in v1. Configuration is
+USB-only.
+
+## Events
+
+`event/diseqc`, non-retained, one per job transition:
+
+```json
+{"v":2,"event_id":14,"sub":"diseqc","comp":"job","transition":"start",
+ "job":7,"op":"goto","state":"running","remaining_ms":89750}
+```
+
+`transition` is `start` or `end`. `event_id` is a monotonic counter for
+ordering within a boot.
+
+## State
+
+`state/diseqc`, retained, republished on connect, after each command, and on
+each job transition:
+
+```json
+{"v":2,"sub":"diseqc","comp":"state","busy":true,"timeout_ms":90000,
+ "active":{"job":7,...},"last":{"job":6,...}}
+```
+
+`active` is the running job or null; `last` is the most recent terminal job or
+null. Consumers should use `event/diseqc` for live transitions and
+`state/diseqc` to establish or recover current state after a reconnect.
+
+Because `active` and `last` are nested objects, `state/diseqc` is **outbound
+only** — it is written by the device, and is outside the flat-object subset the
+inbound parser accepts. Nothing needs to parse it back on the device.
+
+## Versioning
+
+`v` is the contract version and is checked on every inbound command. Additive,
+non-breaking changes (a new op, a new optional response member) keep `v` at 2.
+Anything that changes the meaning or shape of an existing member — including
+migrating an op from `lines` to `data` — increments it.
+
+## Known gaps
+
+- No authentication or authorization on the MQTT transport. Anyone who can
+  publish to `<root>/command` can move the motor. Access control is expected to
+  live in the client that fronts this device, not on the MCU.
+- No TLS. Unchanged from v1 and still deferred.
+- `ts_ms` is an uptime tick, not wall clock. There is no RTC.
+- LNB event and state topics are still schema-1 key/value text.

--- a/docs/software/DEVICE_API_V2.md
+++ b/docs/software/DEVICE_API_V2.md
@@ -1,9 +1,8 @@
 # Device API v2 — JSON Command Envelope And Positioner Jobs
 
 Status: **draft contract**, implemented on the device but not yet exercised on
-hardware. Supersedes the positional MQTT envelope described in
-[MQTT_API.md](MQTT_API.md) for the `command` and `response` topics, and adds a
-positioner job resource to `event/diseqc` and `state/diseqc`.
+hardware. REST is the only network control transport. MQTT is outbound-only and
+announces availability, events, and retained state.
 
 ## Why this exists
 
@@ -28,7 +27,7 @@ network transport carries JSON. Both drive the same hardware paths.
 ```
 USB CDC  ──  IOS-style CLI  ──┐
                               ├──>  operation  ──>  DiSEqC / LNB hardware
-MQTT     ──  JSON envelope  ──┘
+REST     ──  JSON envelope  ──┘
 ```
 
 Nothing in this document changes the console. An operator types
@@ -36,19 +35,13 @@ Nothing in this document changes the console. An operator types
 
 ## Transport
 
-Unchanged from v1: MQTT 3.1.1, no TLS, QoS 1, topic root `<prefix>/<hostname>`.
+Send commands with `POST /api/v2/commands` over HTTP. The request and response
+content type is `application/json`. A command result is returned in the HTTP
+response body; the device does not publish command responses to MQTT.
 
-| Direction | Topic | Payload | Retained |
-|---|---|---|---|
-| Command to device | `<root>/command` | v2 command object | Must be false |
-| Response from device | `<root>/response` | v2 response object, **one per command** | No |
-| Positioner job transition | `<root>/event/diseqc` | v2 event object | No |
-| Current positioner state | `<root>/state/diseqc` | v2 state object | Yes |
-| LNB transition / state | `<root>/event/lnb`, `<root>/state/lnb` | unchanged schema-1 key/value text | see MQTT_API.md |
-| Availability | `<root>/availability` | `online` / `offline` | Yes |
-
-LNB event and state topics are **not** migrated by this change and keep their
-schema-1 key/value form.
+MQTT 3.1.1 remains the announcement transport. Its topic root is
+`<prefix>/<hostname>`; see [MQTT_API.md](MQTT_API.md) for topics and delivery
+semantics. The device does not subscribe to any MQTT topic.
 
 ### Payload constraints
 
@@ -83,17 +76,9 @@ than arrays, e.g. `"frame":"E01038F0"`.
 
 ### `id` is an idempotency key, not a correlation tag
 
-QoS 1 is at-least-once: the broker may redeliver a command, and a redelivered
-`positioner.step` is byte-identical to a genuine second one. Only the publisher
-knows which it is, so the publisher labels it. This is the same role
-`Idempotency-Key` plays in an HTTP API, and it would still be required if this
-were REST.
-
-It is not carried in MQTT 5 `Correlation Data` because the nanoFramework M2Mqtt
-client decodes that property off the wire and then discards it before raising
-`MqttMsgPublishReceived` — `MqttMsgPublishEventArgs` exposes only topic,
-payload, dup flag, QoS and retain. Until that is fixed upstream, an inbound
-correlation token has to live in the payload regardless of protocol version.
+HTTP clients can retry after a timeout without knowing whether the device
+executed the first request. The requester-assigned `id` prevents a retry of a
+non-idempotent operation such as `positioner.step` from executing twice.
 
 ### Deduplication
 
@@ -116,7 +101,7 @@ UUID is ideal, and 32 chars is enough for either).
 
 ## Response envelope
 
-Exactly one response is published per accepted command.
+Exactly one response object is returned per HTTP request.
 
 ```json
 {"v":2,"id":"01J8ZK4M7Q","ok":true,"code":"accepted","job":7,"ts_ms":41231}
@@ -183,8 +168,7 @@ positioner.goto/step/drive ──> running ──┬── positioner.halt ─�
 
 Only one job runs at a time. A motion command while a job is `running` fails
 with `busy` and names the active job; it does not queue. The device retains the
-4 most recent job records, so a terminal job stays queryable via
-`positioner.job` until evicted.
+4 most recent job records for state announcement and release validation.
 
 ### Job object
 
@@ -206,8 +190,6 @@ with `busy` and names the active job; it does not queue. The device retains the
 | `positioner.drive` | `direction` `"east"`\|`"west"` | `accepted` + `job`, or `busy` |
 | `positioner.halt` | — | `ok`; terminates the active job as `halted` |
 | `positioner.release` | `job` int | `ok`; terminates that job as `released` |
-| `positioner.job` | `job` int | `ok` + `data` = job object, or `not_found` |
-| `positioner.show` | — | `ok` + `data` = current state object |
 
 `positioner.release` checks the job id, so a late release for a superseded job
 is rejected rather than ending a newer movement.
@@ -220,25 +202,19 @@ structured `data` object:
 
 | `op` | Parameters | Console equivalent |
 |---|---|---|
-| `system.status` | — | `status` |
-| `system.version` | — | `version` |
-| `system.capabilities` | — | `capabilities` |
-| `lnb.show` | `channel` `"a"`\|`"b"` (optional) | `show lnb [a\|b]` |
 | `lnb.enable` / `lnb.disable` | `channel` | `lnb <ch> enable\|disable` |
 | `lnb.polarization` | `channel`, `value` | `lnb <ch> polarization <value>` |
 | `lnb.band` | `channel`, `value` | `lnb <ch> band <value>` |
 | `diseqc.tx` | `frame` hex string, 1–6 bytes | `diseqc tx <bytes>` |
 | `diseqc.preset` | `value` | `diseqc preset <value>` |
 | `diseqc.tone` | `value` `"on"`\|`"off"` | `diseqc tone <value>` |
-| `diseqc.show` | — | `show diseqc` |
 
 The bridge is a migration stage, not the destination. It exists so the wire
 contract could be finalised in one change without rewriting every handler
 untested. Moving an op from `lines` to `data` is a **breaking change and
 requires a contract version bump** — v2 freezes the shapes above.
 
-Configuration commands remain unavailable on MQTT, as in v1. Configuration is
-USB-only.
+Configuration commands remain USB-only and are not exposed by REST.
 
 ## Events
 
@@ -254,8 +230,7 @@ ordering within a boot.
 
 ## State
 
-`state/diseqc`, retained, republished on connect, after each command, and on
-each job transition:
+`state/diseqc`, retained, republished on connect and on each job transition:
 
 ```json
 {"v":2,"sub":"diseqc","comp":"state","busy":true,"timeout_ms":90000,
@@ -279,9 +254,8 @@ migrating an op from `lines` to `data` — increments it.
 
 ## Known gaps
 
-- No authentication or authorization on the MQTT transport. Anyone who can
-  publish to `<root>/command` can move the motor. Access control is expected to
-  live in the client that fronts this device, not on the MCU.
-- No TLS. Unchanged from v1 and still deferred.
+- REST has no authentication or authorization. Network access to TCP port 80
+  must be restricted to trusted controllers.
+- REST and MQTT have no TLS.
 - `ts_ms` is an uptime tick, not wall clock. There is no RTC.
 - LNB event and state topics are still schema-1 key/value text.

--- a/docs/software/MQTT_API.md
+++ b/docs/software/MQTT_API.md
@@ -1,5 +1,11 @@
 # MQTT API Reference
 
+> **Superseded for commands, responses and DiSEqC topics.** The `command`,
+> `response`, `event/diseqc` and `state/diseqc` topics now carry the JSON
+> contract in [DEVICE_API_V2.md](DEVICE_API_V2.md), which also defines the
+> positioner job model. This document remains authoritative for the LNB topics,
+> connection lifecycle, health monitoring, and configuration, all unchanged.
+
 The target structured payload and subsystem ownership rules are defined in
 [OBSERVABILITY_CONTRACT_V1.md](OBSERVABILITY_CONTRACT_V1.md). This document
 describes the currently implemented MQTT transport; topic migration is tracked in
@@ -11,19 +17,20 @@ CubleyControl uses MQTT 3.1.1 without TLS. It connects through the STM32F407
 Ethernet MAC and LAN8742A PHY after IPv4 and DNS are ready.
 
 The configured topic prefix is `diseqc` by default. The effective device root is
-`<prefix>/<hostname>`. MQTT carries one complete operational command line rather
-than using a separate topic for every operation. It shares the operational parser
-with USB CDC but has a strict allowlist and does not expose administrative
-configuration commands.
+`<prefix>/<hostname>`. Commands arrive as JSON objects on a single topic rather
+than using a separate topic for every operation. Positioner operations are
+dispatched from typed parameters; the remaining operations are still executed by
+the console tokenizer behind a strict allowlist, and administrative
+configuration commands are not exposed.
 
 | Direction | Topic | Payload | QoS | Retained |
 |---|---|---|---:|---|
-| Command to device | `<prefix>/<hostname>/command` | `<id> <command line>` | 1 | Must be false |
-| Response from device | `<prefix>/<hostname>/response` | `id=<id> OK`, `id=<id> Fail: ...`, or requested query output | 1 | No |
+| Command to device | `<prefix>/<hostname>/command` | v2 JSON command object | 1 | Must be false |
+| Response from device | `<prefix>/<hostname>/response` | v2 JSON response object | 1 | No |
 | LNB asynchronous transition | `<prefix>/<hostname>/event/lnb` | Schema-1 LNB event fields | 1 | No |
 | Current LNB state | `<prefix>/<hostname>/state/lnb` | Schema-1 LNB state fields | 1 | Yes |
-| DiSEqC motion transition | `<prefix>/<hostname>/event/diseqc` | Schema-1 motion event fields | 1 | No |
-| Current DiSEqC state | `<prefix>/<hostname>/state/diseqc` | Schema-1 motion state fields | 1 | Yes |
+| Positioner job transition | `<prefix>/<hostname>/event/diseqc` | v2 JSON job event | 1 | No |
+| Current positioner state | `<prefix>/<hostname>/state/diseqc` | v2 JSON state object | 1 | Yes |
 | Device availability | `<prefix>/<hostname>/availability` | `online` or `offline` | 1 | Yes |
 
 The broker receives a retained `online` message after connection. The configured
@@ -36,39 +43,20 @@ but cannot delay or change completion of a hardware command.
 
 ## Commands And Results
 
-Publish a command marked as MQTT-supported in
-[INTERFACE_COMMAND_MAP_V1.md](INTERFACE_COMMAND_MAP_V1.md) to
-`<prefix>/<hostname>/command`. Prefix the command with a requester-assigned decimal
-16-bit ID and one space. State-changing and action commands publish one terminal
-`id=<id> OK` response on success or one `id=<id> Fail: ...` response on failure.
-Queries may publish requested output lines before their terminal response. Each
-published line carries the same ID.
-
-Detailed current condition is owned by retained `state/<subsystem>` topics, while
-asynchronous transitions are owned by `event/<subsystem>`. The compact response
-only acknowledges whether the command completed successfully; it does not repeat
-state or health fields.
-
-Examples:
+See [DEVICE_API_V2.md](DEVICE_API_V2.md) for the command envelope, the operation
+list, result codes, deduplication rules and the positioner job model. In outline:
 
 ```bash
 mosquitto_sub -t 'diseqc/+/response' -t 'diseqc/+/event/+' -t 'diseqc/+/state/+' -t 'diseqc/+/availability' -v
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '41 show lnb a'
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '42 lnb a pol v'
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '43 diseqc goto 12'
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '44 show capabilities'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '{"id":"01J8ZK4M7Q","op":"positioner.goto","position":12}'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '{"id":"01J8ZK4M7R","op":"lnb.polarization","channel":"a","value":"v"}'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '{"id":"01J8ZK4M7S","op":"positioner.halt"}'
 ```
 
-The command line after the ID must be 1 to 64 ASCII bytes. The device rejects
-missing or out-of-range IDs, messages on an unexpected topic, empty or oversized
-payloads, and retained command messages. This prevents a stale retained command
-from executing after reconnect or reboot.
-
-QoS 1 can deliver a command more than once. The device caches the eight most
-recent `{id, command, responses}` transactions in RAM. Repeating the same ID and
-command replays the cached responses without executing the command again. Reusing
-a cached ID for different command text returns an ID-conflict failure. Requesters
-must therefore coordinate IDs when more than one publisher controls a device.
+Exactly one response is published per command. The device rejects messages on an
+unexpected topic, empty or oversized payloads, and retained command messages,
+which prevents a stale retained command from executing after reconnect or
+reboot.
 
 ## Events And State
 
@@ -86,17 +74,12 @@ fault, monitor and initialization state, register values, and channel polarizati
 and band when available. Consumers should use `event/lnb` for live transitions
 and `state/lnb` to establish or recover current state.
 
-`event/diseqc` reports motion start and completion transitions. The retained
-`state/diseqc` snapshot reports `stat`, `motion_id`, `operation`, `remaining_ms`,
-`completion`, and `timeout_ms`. Successful goto, step, and drive commands set the
-state busy. Further movement and raw transmit commands fail as busy until Halt,
-timeout, or `diseqc complete <motion_id>` releases the lock. The ID check prevents
-a stale external completion message from releasing a newer movement. `timeout_ms`
-reflects the configured motion watchdog auto-stop duration, adjustable from the
-USB console with `diseqc timeout <5..300>` (seconds, default 90); it is not yet
-exposed as an MQTT command.
+`event/diseqc` and `state/diseqc` carry the JSON job contract; see
+[DEVICE_API_V2.md](DEVICE_API_V2.md). The motion watchdog duration is still
+adjustable only from the USB console with `diseqc timeout <5..300>` (seconds,
+default 90); it is reported as `timeout_ms` in positioner state.
 
-The compact schema uses `sub`, `comp`, `stat`, and `comm` for subsystem,
+The LNB schema uses `sub`, `comp`, `stat`, and `comm` for subsystem,
 component, status, and communication condition. Local diagnostic sequences use
 `seq`. Retained state omits health and fault sequence counters because they do not
 describe current condition.
@@ -162,6 +145,6 @@ See [CONFIGURATION.md](CONFIGURATION.md) for the complete command list and
 
 ## Scope
 
-No JSON envelope or per-command topic contract is defined for the current MQTT
-transport. TLS, certificate management, and encrypted credential storage are also
-deferred.
+No per-command topic contract is defined. TLS, certificate management, and
+encrypted credential storage remain deferred, as does any authentication or
+authorization of MQTT commands.

--- a/docs/software/MQTT_API.md
+++ b/docs/software/MQTT_API.md
@@ -1,10 +1,8 @@
 # MQTT API Reference
 
-> **Superseded for commands, responses and DiSEqC topics.** The `command`,
-> `response`, `event/diseqc` and `state/diseqc` topics now carry the JSON
-> contract in [DEVICE_API_V2.md](DEVICE_API_V2.md), which also defines the
-> positioner job model. This document remains authoritative for the LNB topics,
-> connection lifecycle, health monitoring, and configuration, all unchanged.
+MQTT is an outbound-only state announcement interface. CubleyControl does not
+subscribe to command topics and MQTT cannot initiate hardware operations. REST
+control is defined in [DEVICE_API_V2.md](DEVICE_API_V2.md).
 
 The target structured payload and subsystem ownership rules are defined in
 [OBSERVABILITY_CONTRACT_V1.md](OBSERVABILITY_CONTRACT_V1.md). This document
@@ -17,16 +15,10 @@ CubleyControl uses MQTT 3.1.1 without TLS. It connects through the STM32F407
 Ethernet MAC and LAN8742A PHY after IPv4 and DNS are ready.
 
 The configured topic prefix is `diseqc` by default. The effective device root is
-`<prefix>/<hostname>`. Commands arrive as JSON objects on a single topic rather
-than using a separate topic for every operation. Positioner operations are
-dispatched from typed parameters; the remaining operations are still executed by
-the console tokenizer behind a strict allowlist, and administrative
-configuration commands are not exposed.
+`<prefix>/<hostname>`.
 
 | Direction | Topic | Payload | QoS | Retained |
 |---|---|---|---:|---|
-| Command to device | `<prefix>/<hostname>/command` | v2 JSON command object | 1 | Must be false |
-| Response from device | `<prefix>/<hostname>/response` | v2 JSON response object | 1 | No |
 | LNB asynchronous transition | `<prefix>/<hostname>/event/lnb` | Schema-1 LNB event fields | 1 | No |
 | Current LNB state | `<prefix>/<hostname>/state/lnb` | Schema-1 LNB state fields | 1 | Yes |
 | Positioner job transition | `<prefix>/<hostname>/event/diseqc` | v2 JSON job event | 1 | No |
@@ -36,27 +28,16 @@ configuration commands are not exposed.
 The broker receives a retained `online` message after connection. The configured
 last will is retained `offline` at QoS 1.
 
-LNB and DiSEqC execution does not perform socket I/O. Responses, events, and state
+LNB and DiSEqC execution does not perform socket I/O. Events and state
 updates are placed in a bounded queue and published only by the MQTT worker. A
 broker failure, blocked publish, or full publication queue can lose MQTT output,
 but cannot delay or change completion of a hardware command.
 
-## Commands And Results
-
-See [DEVICE_API_V2.md](DEVICE_API_V2.md) for the command envelope, the operation
-list, result codes, deduplication rules and the positioner job model. In outline:
+## Monitoring
 
 ```bash
-mosquitto_sub -t 'diseqc/+/response' -t 'diseqc/+/event/+' -t 'diseqc/+/state/+' -t 'diseqc/+/availability' -v
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '{"id":"01J8ZK4M7Q","op":"positioner.goto","position":12}'
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '{"id":"01J8ZK4M7R","op":"lnb.polarization","channel":"a","value":"v"}'
-mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '{"id":"01J8ZK4M7S","op":"positioner.halt"}'
+mosquitto_sub -t 'diseqc/+/event/+' -t 'diseqc/+/state/+' -t 'diseqc/+/availability' -v
 ```
-
-Exactly one response is published per command. The device rejects messages on an
-unexpected topic, empty or oversized payloads, and retained command messages,
-which prevents a stale retained command from executing after reconnect or
-reboot.
 
 ## Events And State
 
@@ -67,8 +48,8 @@ published.
 The GPIO callback only signals a worker; register inspection and MQTT publication
 run outside the interrupt callback.
 
-`state/lnb` is a retained snapshot published on connection, after each MQTT
-command, and after each fault transition. It begins with
+`state/lnb` is a retained snapshot published on connection, after each successful
+LNB control change, and after each fault transition. It begins with
 `schema=1 sub=lnb comp=state` and includes health, communication,
 fault, monitor and initialization state, register values, and channel polarization
 and band when available. Consumers should use `event/lnb` for live transitions
@@ -137,14 +118,12 @@ cubley-a1b2c3(config*)# commit
 
 The broker must be set before an enabled configuration can be committed. Credentials
 are case-preserving but cannot contain spaces in schema v2. Password commands are
-redacted from debug logs and configuration output. MQTT messages containing
-configuration commands are rejected as unsupported.
+redacted from debug logs and configuration output.
 
 See [CONFIGURATION.md](CONFIGURATION.md) for the complete command list and
 [CONFIGURATION_STORAGE.md](CONFIGURATION_STORAGE.md) for the persisted schema.
 
 ## Scope
 
-No per-command topic contract is defined. TLS, certificate management, and
-encrypted credential storage remain deferred, as does any authentication or
-authorization of MQTT commands.
+There are no MQTT command or response topics. TLS, certificate management, and
+encrypted credential storage remain deferred.

--- a/software/nanoFramework/CubleyControl/CubleyControl.nfproj
+++ b/software/nanoFramework/CubleyControl/CubleyControl.nfproj
@@ -23,6 +23,7 @@
     <Compile Include="ApplicationConfigurationStorage.cs" />
     <Compile Include="BuildInfo.cs" Condition=" '$(BuildInfoSource)' == '' " />
     <Compile Include="$(BuildInfoSource)" Condition=" '$(BuildInfoSource)' != '' " />
+    <Compile Include="Json.cs" />
     <Compile Include="Program.Commands.Configuration.cs" />
     <Compile Include="Program.Commands.Diseqc.cs" />
     <Compile Include="Program.Commands.Lnb.cs" />
@@ -30,6 +31,7 @@
     <Compile Include="Program.Commands.MqttConfig.cs" />
     <Compile Include="Program.Commands.Network.cs" />
     <Compile Include="Program.Commands.cs" />
+    <Compile Include="Program.Jobs.cs" />
     <Compile Include="Program.LnbHealth.cs" />
     <Compile Include="Program.Network.cs" />
     <Compile Include="Program.MqttConfiguration.cs" />

--- a/software/nanoFramework/CubleyControl/CubleyControl.nfproj
+++ b/software/nanoFramework/CubleyControl/CubleyControl.nfproj
@@ -30,6 +30,7 @@
     <Compile Include="Program.Commands.Mqtt.cs" />
     <Compile Include="Program.Commands.MqttConfig.cs" />
     <Compile Include="Program.Commands.Network.cs" />
+    <Compile Include="Program.Commands.Rest.cs" />
     <Compile Include="Program.Commands.cs" />
     <Compile Include="Program.Jobs.cs" />
     <Compile Include="Program.LnbHealth.cs" />
@@ -59,10 +60,10 @@
       <HintPath>..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt">
-      <HintPath>..\packages\nanoFramework.M2Mqtt.5.1.221\lib\nanoFramework.M2Mqtt.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.M2Mqtt.5.1.223\lib\nanoFramework.M2Mqtt.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt.Core">
-      <HintPath>..\packages\nanoFramework.M2Mqtt.5.1.221\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.M2Mqtt.5.1.223\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Hardware.Stm32">
       <HintPath>..\packages\nanoFramework.Hardware.Stm32.1.10.37\lib\nanoFramework.Hardware.Stm32.dll</HintPath>
@@ -77,7 +78,7 @@
       <HintPath>..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
     </Reference>
     <Reference Include="System.Net">
-      <HintPath>..\packages\nanoFramework.System.Net.1.11.60\lib\System.Net.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.System.Net.1.11.64\lib\System.Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/software/nanoFramework/CubleyControl/Json.cs
+++ b/software/nanoFramework/CubleyControl/Json.cs
@@ -1,0 +1,660 @@
+using System;
+
+namespace CubleyControl
+{
+    /// <summary>
+    /// Bounded reader for the flat JSON object subset defined by
+    /// docs/software/DEVICE_API_V2.md: string, integer, boolean and null
+    /// members only, with no nesting. The limits are part of the wire
+    /// contract rather than an implementation detail -- they are what keeps
+    /// inbound parsing allocation-bounded on a 192 KB target.
+    /// </summary>
+    internal sealed class JsonObject
+    {
+        internal const int MaxMembers = 12;
+        internal const int MaxKeyLength = 24;
+        internal const int MaxStringLength = 128;
+
+        internal const int KindString = 0;
+        internal const int KindInt = 1;
+        internal const int KindBool = 2;
+        internal const int KindNull = 3;
+
+        private readonly string[] _keys = new string[MaxMembers];
+        private readonly string[] _strings = new string[MaxMembers];
+        private readonly int[] _numbers = new int[MaxMembers];
+        private readonly int[] _kinds = new int[MaxMembers];
+        private int _count;
+
+        internal int Count
+        {
+            get { return _count; }
+        }
+
+        internal string KeyAt(int index)
+        {
+            return index < 0 || index >= _count ? null : _keys[index];
+        }
+
+        internal bool Add(string key, int kind, string text, int number)
+        {
+            if (_count >= MaxMembers || IndexOf(key) >= 0)
+            {
+                return false;
+            }
+
+            _keys[_count] = key;
+            _kinds[_count] = kind;
+            _strings[_count] = text;
+            _numbers[_count] = number;
+            _count++;
+            return true;
+        }
+
+        internal int IndexOf(string key)
+        {
+            for (int index = 0; index < _count; index++)
+            {
+                if (_keys[index] == key)
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        internal bool Has(string key)
+        {
+            return IndexOf(key) >= 0;
+        }
+
+        /// <summary>Null members read as absent, so "x":null and a missing x behave alike.</summary>
+        internal bool TryGetString(string key, out string value)
+        {
+            value = null;
+            int index = IndexOf(key);
+            if (index < 0 || _kinds[index] != KindString)
+            {
+                return false;
+            }
+
+            value = _strings[index];
+            return true;
+        }
+
+        internal bool TryGetInt(string key, out int value)
+        {
+            value = 0;
+            int index = IndexOf(key);
+            if (index < 0 || _kinds[index] != KindInt)
+            {
+                return false;
+            }
+
+            value = _numbers[index];
+            return true;
+        }
+
+        internal bool TryGetBool(string key, out bool value)
+        {
+            value = false;
+            int index = IndexOf(key);
+            if (index < 0 || _kinds[index] != KindBool)
+            {
+                return false;
+            }
+
+            value = _numbers[index] != 0;
+            return true;
+        }
+    }
+
+    internal static class Json
+    {
+        internal static bool TryParseObject(string text, out JsonObject result, out string error)
+        {
+            result = null;
+            error = string.Empty;
+
+            if (text == null || text.Length == 0)
+            {
+                error = "empty payload";
+                return false;
+            }
+
+            JsonObject obj = new JsonObject();
+            int index = SkipWhitespace(text, 0);
+            if (index >= text.Length || text[index] != '{')
+            {
+                error = "payload must be a JSON object";
+                return false;
+            }
+
+            index++;
+            index = SkipWhitespace(text, index);
+            if (index < text.Length && text[index] == '}')
+            {
+                index = SkipWhitespace(text, index + 1);
+                if (index != text.Length)
+                {
+                    error = "trailing content after object";
+                    return false;
+                }
+
+                result = obj;
+                return true;
+            }
+
+            while (true)
+            {
+                index = SkipWhitespace(text, index);
+                string key;
+                if (index >= text.Length || text[index] != '"')
+                {
+                    error = "expected a member name";
+                    return false;
+                }
+
+                if (!TryParseString(text, ref index, JsonObject.MaxKeyLength, out key, out error))
+                {
+                    return false;
+                }
+
+                if (key.Length == 0)
+                {
+                    error = "member name must not be empty";
+                    return false;
+                }
+
+                index = SkipWhitespace(text, index);
+                if (index >= text.Length || text[index] != ':')
+                {
+                    error = "expected ':' after member name " + key;
+                    return false;
+                }
+
+                index = SkipWhitespace(text, index + 1);
+                if (index >= text.Length)
+                {
+                    error = "missing value for member " + key;
+                    return false;
+                }
+
+                int kind;
+                string valueText = null;
+                int valueNumber = 0;
+                char lead = text[index];
+                if (lead == '"')
+                {
+                    if (!TryParseString(text, ref index, JsonObject.MaxStringLength, out valueText, out error))
+                    {
+                        return false;
+                    }
+
+                    kind = JsonObject.KindString;
+                }
+                else if (lead == 't' || lead == 'f')
+                {
+                    bool boolValue;
+                    if (!TryParseLiteralBool(text, ref index, out boolValue))
+                    {
+                        error = "invalid value for member " + key;
+                        return false;
+                    }
+
+                    kind = JsonObject.KindBool;
+                    valueNumber = boolValue ? 1 : 0;
+                }
+                else if (lead == 'n')
+                {
+                    if (!TryParseLiteral(text, ref index, "null"))
+                    {
+                        error = "invalid value for member " + key;
+                        return false;
+                    }
+
+                    kind = JsonObject.KindNull;
+                }
+                else if (lead == '-' || (lead >= '0' && lead <= '9'))
+                {
+                    if (!TryParseInteger(text, ref index, out valueNumber, out error))
+                    {
+                        return false;
+                    }
+
+                    kind = JsonObject.KindInt;
+                }
+                else if (lead == '{' || lead == '[')
+                {
+                    error = "member " + key + " must be a scalar; objects and arrays are not accepted";
+                    return false;
+                }
+                else
+                {
+                    error = "invalid value for member " + key;
+                    return false;
+                }
+
+                if (!obj.Add(key, kind, valueText, valueNumber))
+                {
+                    error = obj.Has(key)
+                        ? "duplicate member " + key
+                        : "too many members; limit is " + JsonObject.MaxMembers.ToString();
+                    return false;
+                }
+
+                index = SkipWhitespace(text, index);
+                if (index < text.Length && text[index] == ',')
+                {
+                    index++;
+                    continue;
+                }
+
+                if (index < text.Length && text[index] == '}')
+                {
+                    index++;
+                    break;
+                }
+
+                error = "expected ',' or '}' after member " + key;
+                return false;
+            }
+
+            index = SkipWhitespace(text, index);
+            if (index != text.Length)
+            {
+                error = "trailing content after object";
+                return false;
+            }
+
+            result = obj;
+            return true;
+        }
+
+        private static int SkipWhitespace(string text, int index)
+        {
+            while (index < text.Length)
+            {
+                char current = text[index];
+                if (current != ' ' && current != '\t' && current != '\r' && current != '\n')
+                {
+                    break;
+                }
+
+                index++;
+            }
+
+            return index;
+        }
+
+        private static bool TryParseString(string text, ref int index, int maxLength, out string value, out string error)
+        {
+            value = null;
+            error = string.Empty;
+
+            // Caller has already checked for the opening quote.
+            int cursor = index + 1;
+            string accumulated = string.Empty;
+            while (true)
+            {
+                if (cursor >= text.Length)
+                {
+                    error = "unterminated string";
+                    return false;
+                }
+
+                char current = text[cursor];
+                if (current == '"')
+                {
+                    cursor++;
+                    break;
+                }
+
+                if (current == '\\')
+                {
+                    cursor++;
+                    if (cursor >= text.Length)
+                    {
+                        error = "unterminated escape sequence";
+                        return false;
+                    }
+
+                    char escape = text[cursor];
+                    if (escape == '"' || escape == '\\' || escape == '/')
+                    {
+                        accumulated += escape;
+                    }
+                    else if (escape == 'b')
+                    {
+                        accumulated += '\b';
+                    }
+                    else if (escape == 'f')
+                    {
+                        accumulated += '\f';
+                    }
+                    else if (escape == 'n')
+                    {
+                        accumulated += '\n';
+                    }
+                    else if (escape == 'r')
+                    {
+                        accumulated += '\r';
+                    }
+                    else if (escape == 't')
+                    {
+                        accumulated += '\t';
+                    }
+                    else if (escape == 'u')
+                    {
+                        int codePoint = 0;
+                        for (int digit = 0; digit < 4; digit++)
+                        {
+                            cursor++;
+                            int nibble;
+                            if (cursor >= text.Length || !TryHexDigit(text[cursor], out nibble))
+                            {
+                                error = "invalid \\u escape sequence";
+                                return false;
+                            }
+
+                            codePoint = (codePoint << 4) | nibble;
+                        }
+
+                        accumulated += (char)codePoint;
+                    }
+                    else
+                    {
+                        error = "invalid escape sequence";
+                        return false;
+                    }
+
+                    cursor++;
+                    if (accumulated.Length > maxLength)
+                    {
+                        error = "string exceeds " + maxLength.ToString() + " characters";
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                if (current < ' ')
+                {
+                    error = "unescaped control character in string";
+                    return false;
+                }
+
+                accumulated += current;
+                cursor++;
+                if (accumulated.Length > maxLength)
+                {
+                    error = "string exceeds " + maxLength.ToString() + " characters";
+                    return false;
+                }
+            }
+
+            index = cursor;
+            value = accumulated;
+            return true;
+        }
+
+        private static bool TryParseInteger(string text, ref int index, out int value, out string error)
+        {
+            value = 0;
+            error = string.Empty;
+
+            int cursor = index;
+            bool negative = false;
+            if (text[cursor] == '-')
+            {
+                negative = true;
+                cursor++;
+                if (cursor >= text.Length || text[cursor] < '0' || text[cursor] > '9')
+                {
+                    error = "malformed number";
+                    return false;
+                }
+            }
+
+            int digitStart = cursor;
+            long accumulated = 0;
+            while (cursor < text.Length && text[cursor] >= '0' && text[cursor] <= '9')
+            {
+                accumulated = (accumulated * 10) + (text[cursor] - '0');
+                if (accumulated > 2147483648L)
+                {
+                    error = "number out of range";
+                    return false;
+                }
+
+                cursor++;
+            }
+
+            int digitCount = cursor - digitStart;
+            if (digitCount == 0)
+            {
+                error = "malformed number";
+                return false;
+            }
+
+            if (digitCount > 1 && text[digitStart] == '0')
+            {
+                error = "number must not have a leading zero";
+                return false;
+            }
+
+            if (cursor < text.Length)
+            {
+                char trailing = text[cursor];
+                if (trailing == '.' || trailing == 'e' || trailing == 'E')
+                {
+                    error = "number must be an integer";
+                    return false;
+                }
+            }
+
+            if (negative)
+            {
+                if (accumulated > 2147483648L)
+                {
+                    error = "number out of range";
+                    return false;
+                }
+
+                value = (int)(-accumulated);
+            }
+            else
+            {
+                if (accumulated > 2147483647L)
+                {
+                    error = "number out of range";
+                    return false;
+                }
+
+                value = (int)accumulated;
+            }
+
+            index = cursor;
+            return true;
+        }
+
+        private static bool TryParseLiteralBool(string text, ref int index, out bool value)
+        {
+            if (TryParseLiteral(text, ref index, "true"))
+            {
+                value = true;
+                return true;
+            }
+
+            value = false;
+            return TryParseLiteral(text, ref index, "false");
+        }
+
+        private static bool TryParseLiteral(string text, ref int index, string literal)
+        {
+            if (index + literal.Length > text.Length)
+            {
+                return false;
+            }
+
+            for (int offset = 0; offset < literal.Length; offset++)
+            {
+                if (text[index + offset] != literal[offset])
+                {
+                    return false;
+                }
+            }
+
+            index += literal.Length;
+            return true;
+        }
+
+        private static bool TryHexDigit(char value, out int result)
+        {
+            if (value >= '0' && value <= '9')
+            {
+                result = value - '0';
+                return true;
+            }
+
+            if (value >= 'a' && value <= 'f')
+            {
+                result = 10 + (value - 'a');
+                return true;
+            }
+
+            if (value >= 'A' && value <= 'F')
+            {
+                result = 10 + (value - 'A');
+                return true;
+            }
+
+            result = 0;
+            return false;
+        }
+
+        /// <summary>Quotes and escapes a string for inclusion in an outbound payload.</summary>
+        internal static string Quote(string value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            string escaped = "\"";
+            for (int index = 0; index < value.Length; index++)
+            {
+                char current = value[index];
+                if (current == '"')
+                {
+                    escaped += "\\\"";
+                }
+                else if (current == '\\')
+                {
+                    escaped += "\\\\";
+                }
+                else if (current == '\n')
+                {
+                    escaped += "\\n";
+                }
+                else if (current == '\r')
+                {
+                    escaped += "\\r";
+                }
+                else if (current == '\t')
+                {
+                    escaped += "\\t";
+                }
+                else if (current == '\b')
+                {
+                    escaped += "\\b";
+                }
+                else if (current == '\f')
+                {
+                    escaped += "\\f";
+                }
+                else if (current < ' ' || current > '~')
+                {
+                    // The device contract is ASCII; anything outside it is
+                    // escaped rather than emitted raw so the payload stays
+                    // valid for consumers that assume UTF-8.
+                    escaped += "\\u" + ToHex4(current);
+                }
+                else
+                {
+                    escaped += current;
+                }
+            }
+
+            return escaped + "\"";
+        }
+
+        private static string ToHex4(char value)
+        {
+            const string Digits = "0123456789abcdef";
+            int code = value;
+            return new string(new char[]
+            {
+                Digits[(code >> 12) & 0xF],
+                Digits[(code >> 8) & 0xF],
+                Digits[(code >> 4) & 0xF],
+                Digits[code & 0xF]
+            });
+        }
+    }
+
+    /// <summary>Minimal ordered writer for outbound payloads.</summary>
+    internal sealed class JsonBuilder
+    {
+        private string _text = "{";
+        private bool _hasMember;
+
+        internal JsonBuilder AddString(string key, string value)
+        {
+            return AddRaw(key, Json.Quote(value));
+        }
+
+        internal JsonBuilder AddInt(string key, int value)
+        {
+            return AddRaw(key, value.ToString());
+        }
+
+        internal JsonBuilder AddLong(string key, long value)
+        {
+            return AddRaw(key, value.ToString());
+        }
+
+        internal JsonBuilder AddBool(string key, bool value)
+        {
+            return AddRaw(key, value ? "true" : "false");
+        }
+
+        /// <summary>Adds a pre-serialized value: a nested object, or "null".</summary>
+        internal JsonBuilder AddRaw(string key, string rawValue)
+        {
+            if (_hasMember)
+            {
+                _text += ",";
+            }
+
+            _text += Json.Quote(key) + ":" + rawValue;
+            _hasMember = true;
+            return this;
+        }
+
+        internal string Build()
+        {
+            return _text + "}";
+        }
+
+        /// <summary>
+        /// The member list without enclosing braces, so a cached response can
+        /// be republished with an extra member added.
+        /// </summary>
+        internal string BuildBody()
+        {
+            return _text.Substring(1);
+        }
+    }
+}

--- a/software/nanoFramework/CubleyControl/Program.Commands.Configuration.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Configuration.cs
@@ -722,25 +722,5 @@ namespace CubleyControl
             }
         }
 
-        private static bool IsMqttOperationalCommand(string[] tokens)
-        {
-            string head = tokens[0];
-            if (head == "status" || head == "st" || head == "capabilities" || head == "caps" ||
-                head == "version" || head == "ver" || head == "lnb" || head == "l" || head == "diseqc")
-            {
-                return true;
-            }
-
-            if (head == "show")
-            {
-                return tokens.Length == 1 ||
-                    (tokens.Length >= 2 &&
-                        (tokens[1] == "lnb" || tokens[1] == "diseqc" || tokens[1] == "status" ||
-                            tokens[1] == "version" || tokens[1] == "ver" ||
-                            tokens[1] == "capabilities" || tokens[1] == "caps"));
-            }
-
-            return false;
-        }
     }
 }

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -21,18 +21,20 @@ namespace CubleyControl
         private const int DiseqcStepBaseTimeMs = 1000;
         private const int DiseqcStepTimePerStepMs = 250;
 
+        private const int PositionerOpGoto = 1;
+        private const int PositionerOpStepEast = 2;
+        private const int PositionerOpStepWest = 3;
+        private const int PositionerOpDriveEast = 4;
+        private const int PositionerOpDriveWest = 5;
+        private const int PositionerOpHalt = 6;
+
         private static bool _diseqcCarrierEnabled;
         private static int _diseqcCarrierFrequencyHz;
         private static int _diseqcCarrierDutyPercent;
         private static bool _diseqcTxBusy;
         private static DiseqcV1RoutePreset _diseqcRoutePreset = DiseqcV1RoutePreset.Direct;
-        private static readonly object _diseqcMotionLock = new object();
-        private static bool _diseqcMotionBusy;
-        private static int _diseqcMotionId;
-        private static int _diseqcNextMotionId;
-        private static string _diseqcMotionOperation = "idle";
-        private static long _diseqcMotionDeadlineMs;
-        private static string _diseqcMotionCompletionSource = "none";
+        // Motion state lives in the positioner job store (Program.Jobs.cs).
+        // Only the watchdog duration is configuration rather than job state.
         private static int _diseqcMotionTimeoutMs = DiseqcMotionWorstCaseMs;
 
         private static void HandleDiseqcCommand(string[] tokens, int reqId)
@@ -172,6 +174,76 @@ namespace CubleyControl
             }
 
             WriteCommandResult(reqId, false, "validation_error", "diseqc syntax invalid", "verb=" + verb);
+        }
+
+        /// <summary>
+        /// Typed entry point shared with the JSON transport. Mirrors the
+        /// console verbs in HandleDiseqcCommand without the tokenizing, so
+        /// both routes reach the same hardware path and the same job store.
+        /// </summary>
+        private static void RunPositionerOperation(int operation, int value)
+        {
+            int reqId = NextRequestId();
+            _activeCommandIsSetter = true;
+
+            if (operation == PositionerOpHalt)
+            {
+                _activeCommand = "positioner halt";
+                EmitDiseqcPositionerTransmitResult(reqId, "diseqc stop", DiseqcCommandBuilder.BuildHalt(), null, 0);
+                return;
+            }
+
+            if (!EnsureDiseqcMotionIdle(reqId))
+            {
+                return;
+            }
+
+            if (operation == PositionerOpGoto)
+            {
+                _activeCommand = "positioner goto";
+                EmitDiseqcPositionerTransmitResult(
+                    reqId,
+                    "diseqc goto",
+                    DiseqcCommandBuilder.BuildGotoStoredPosition((byte)value),
+                    "goto",
+                    _diseqcMotionTimeoutMs);
+                return;
+            }
+
+            if (operation == PositionerOpStepEast || operation == PositionerOpStepWest)
+            {
+                bool east = operation == PositionerOpStepEast;
+                _activeCommand = "positioner step";
+                EmitDiseqcPositionerTransmitResult(
+                    reqId,
+                    "diseqc step",
+                    east
+                        ? DiseqcCommandBuilder.BuildStepEast((byte)value)
+                        : DiseqcCommandBuilder.BuildStepWest((byte)value),
+                    east ? "step_east" : "step_west",
+                    DiseqcStepBaseTimeMs + (value * DiseqcStepTimePerStepMs));
+                return;
+            }
+
+            if (operation == PositionerOpDriveEast || operation == PositionerOpDriveWest)
+            {
+                bool east = operation == PositionerOpDriveEast;
+                _activeCommand = "positioner drive";
+                EmitDiseqcPositionerTransmitResult(
+                    reqId,
+                    "diseqc drive",
+                    east ? DiseqcCommandBuilder.BuildDriveEast() : DiseqcCommandBuilder.BuildDriveWest(),
+                    east ? "drive_east" : "drive_west",
+                    _diseqcMotionTimeoutMs);
+                return;
+            }
+
+            WriteCommandResult(
+                reqId,
+                false,
+                "unsupported",
+                "unknown positioner operation",
+                "operation=" + operation.ToString());
         }
 
         private static void EmitDiseqcShowSummaryLine()
@@ -395,23 +467,26 @@ namespace CubleyControl
 
         private static bool EnsureDiseqcMotionIdle(int reqId)
         {
-            bool busy;
-            int motionId;
-            string operation;
-            int remainingMs;
-            string completionSource;
-            GetDiseqcMotionSnapshot(out busy, out motionId, out operation, out remainingMs, out completionSource);
-            if (!busy)
+            int activeJobId = GetActiveDiseqcJobId();
+            if (activeJobId == 0)
             {
                 return true;
             }
 
+            string operation;
+            string state;
+            int remainingMs;
+            int timeoutMs;
+            string detail;
+            TryGetDiseqcJobSnapshot(activeJobId, out operation, out state, out remainingMs, out timeoutMs, out detail);
+
+            _blockingDiseqcJobId = activeJobId;
             WriteCommandResult(
                 reqId,
                 false,
                 "busy",
                 "diseqc motion busy",
-                "motion_id=" + motionId.ToString() +
+                "motion_id=" + activeJobId.ToString() +
                 " operation=" + operation +
                 " remaining_ms=" + remainingMs.ToString());
             return false;
@@ -426,94 +501,55 @@ namespace CubleyControl
                 return;
             }
 
-            lock (_diseqcMotionLock)
+            int activeJobId = GetActiveDiseqcJobId();
+            if (activeJobId == 0)
             {
-                if (!_diseqcMotionBusy)
-                {
-                    WriteCommandResult(reqId, false, "validation_error", "no diseqc motion", "motion_id=0");
-                    return;
-                }
-
-                if (_diseqcMotionId != requestedMotionId)
-                {
-                    WriteCommandResult(
-                        reqId,
-                        false,
-                        "validation_error",
-                        "diseqc motion id mismatch",
-                        "motion_id=" + _diseqcMotionId.ToString());
-                    return;
-                }
-
-                ClearDiseqcMotionLocked("external");
+                WriteCommandResult(reqId, false, "validation_error", "no diseqc motion", "motion_id=0");
+                return;
             }
 
-            PublishMqttDiseqcMotionTransition("complete");
+            if (activeJobId != requestedMotionId)
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc motion id mismatch",
+                    "motion_id=" + activeJobId.ToString());
+                return;
+            }
+
+            if (!TryEndDiseqcJob(requestedMotionId, JobStateReleased, string.Empty))
+            {
+                WriteCommandResult(reqId, false, "validation_error", "diseqc motion id mismatch", "motion_id=" + activeJobId.ToString());
+                return;
+            }
+
+            PublishMqttDiseqcJobTransition("end", requestedMotionId);
             WriteCommandResult(reqId, true, "ok", "diseqc complete", "motion_id=" + requestedMotionId.ToString());
         }
 
+        /// <summary>
+        /// A null <paramref name="operation"/> means the transmitted frame was
+        /// a Halt, which ends any running job rather than starting one.
+        /// </summary>
         private static void CompleteOrBeginDiseqcMotion(string operation, int durationMs)
         {
             if (operation == null)
             {
-                bool wasBusy;
-                lock (_diseqcMotionLock)
+                int haltedJobId = EndActiveDiseqcJob(JobStateHalted, string.Empty);
+                if (haltedJobId != 0)
                 {
-                    wasBusy = _diseqcMotionBusy;
-                    ClearDiseqcMotionLocked("halt");
+                    _lastStartedDiseqcJobId = haltedJobId;
+                    PublishMqttDiseqcJobTransition("end", haltedJobId);
                 }
 
-                if (wasBusy)
-                {
-                    PublishMqttDiseqcMotionTransition("complete");
-                }
                 return;
             }
 
-            lock (_diseqcMotionLock)
-            {
-                _diseqcNextMotionId++;
-                if (_diseqcNextMotionId <= 0)
-                {
-                    _diseqcNextMotionId = 1;
-                }
-
-                long nowMs = Environment.TickCount64;
-                _diseqcMotionBusy = true;
-                _diseqcMotionId = _diseqcNextMotionId;
-                _diseqcMotionOperation = operation;
-                _diseqcMotionDeadlineMs = nowMs +
-                    (durationMs < _diseqcMotionTimeoutMs ? durationMs : _diseqcMotionTimeoutMs);
-                _diseqcMotionCompletionSource = "pending";
-            }
-
-            PublishMqttDiseqcMotionTransition("start");
-        }
-
-        private static void ClearDiseqcMotionLocked(string completionSource)
-        {
-            _diseqcMotionBusy = false;
-            _diseqcMotionOperation = "idle";
-            _diseqcMotionDeadlineMs = 0;
-            _diseqcMotionCompletionSource = completionSource;
-        }
-
-        private static void GetDiseqcMotionSnapshot(
-            out bool busy,
-            out int motionId,
-            out string operation,
-            out int remainingMs,
-            out string completionSource)
-        {
-            lock (_diseqcMotionLock)
-            {
-                busy = _diseqcMotionBusy;
-                motionId = _diseqcMotionId;
-                operation = _diseqcMotionOperation;
-                completionSource = _diseqcMotionCompletionSource;
-                long remaining = busy ? _diseqcMotionDeadlineMs - Environment.TickCount64 : 0;
-                remainingMs = remaining <= 0 ? 0 : (remaining > int.MaxValue ? int.MaxValue : (int)remaining);
-            }
+            int jobId = BeginDiseqcJob(operation, durationMs);
+            _lastStartedDiseqcJobId = jobId;
+            PublishMqttDiseqcJobTransition("start", jobId);
         }
 
         private static string BuildDiseqcMotionResultData()
@@ -535,29 +571,20 @@ namespace CubleyControl
             {
                 Thread.Sleep(DiseqcMotionPollIntervalMs);
 
-                int expiredMotionId = 0;
-                lock (_diseqcMotionLock)
-                {
-                    if (_diseqcMotionBusy && Environment.TickCount64 >= _diseqcMotionDeadlineMs)
-                    {
-                        expiredMotionId = _diseqcMotionId;
-                    }
-                }
-
-                if (expiredMotionId == 0)
+                int expiredJobId = GetExpiredDiseqcJobId();
+                if (expiredJobId == 0)
                 {
                     continue;
                 }
 
+                bool ended;
                 lock (_commandLock)
                 {
-                    lock (_diseqcMotionLock)
+                    // Re-check under the command lock: the job may have been
+                    // halted or released while this loop was waiting for it.
+                    if (GetExpiredDiseqcJobId() != expiredJobId)
                     {
-                        if (!_diseqcMotionBusy || _diseqcMotionId != expiredMotionId ||
-                            Environment.TickCount64 < _diseqcMotionDeadlineMs)
-                        {
-                            continue;
-                        }
+                        continue;
                     }
 
                     string error;
@@ -574,16 +601,15 @@ namespace CubleyControl
                         EndLnbIoOperation();
                     }
 
-                    lock (_diseqcMotionLock)
-                    {
-                        if (_diseqcMotionBusy && _diseqcMotionId == expiredMotionId)
-                        {
-                            ClearDiseqcMotionLocked(error.Length == 0 ? "timeout" : "timeout_halt_failed");
-                        }
-                    }
+                    ended = error.Length == 0
+                        ? TryEndDiseqcJob(expiredJobId, JobStateTimeout, string.Empty)
+                        : TryEndDiseqcJob(expiredJobId, JobStateTimeoutHaltFailed, SanitizeToken(error));
                 }
 
-                PublishMqttDiseqcMotionTransition("complete");
+                if (ended)
+                {
+                    PublishMqttDiseqcJobTransition("end", expiredJobId);
+                }
             }
         }
 

--- a/software/nanoFramework/CubleyControl/Program.Commands.Lnb.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Lnb.cs
@@ -170,6 +170,7 @@ namespace CubleyControl
 
                 if (rc == (int)LNBH26.Status.Ok)
                 {
+                    PublishMqttState();
                     WriteCommandResult(reqId, true, "ok", "lnb " + field, "channel=" + LnbChannelToSchemaName(channel) + " value=" + (enable ? "on" : "off"));
                 }
                 else
@@ -207,6 +208,7 @@ namespace CubleyControl
                 int rc = LNBH26.NativeSetPolarizationForChannel(channel, polarization);
                 if (rc == (int)LNBH26.Status.Ok)
                 {
+                    PublishMqttState();
                     WriteCommandResult(reqId, true, "ok", "lnb polarization", "channel=" + LnbChannelToSchemaName(channel) + " value=" + PolarizationToText(polarization));
                 }
                 else
@@ -238,6 +240,7 @@ namespace CubleyControl
                         _diseqcCarrierDutyPercent = 0;
                     }
 
+                    PublishMqttState();
                     WriteCommandResult(reqId, true, "ok", "lnb band", "channel=" + LnbChannelToSchemaName(channel) + " value=" + BandToText(band));
                 }
                 else
@@ -260,6 +263,7 @@ namespace CubleyControl
                 int rc = LNBH26Tweaks.NativeSetIsetLowForChannel(channel, lowRange);
                 if (rc == (int)LNBH26.Status.Ok)
                 {
+                    PublishMqttState();
                     WriteCommandResult(reqId, true, "ok", "lnb iset", "channel=" + LnbChannelToSchemaName(channel) + " value=" + IsetToText(lowRange ? 1 : 0));
                 }
                 else
@@ -282,6 +286,7 @@ namespace CubleyControl
                 int rc = LNBH26Tweaks.NativeSetIswLowForChannel(channel, lowLimit);
                 if (rc == (int)LNBH26.Status.Ok)
                 {
+                    PublishMqttState();
                     WriteCommandResult(reqId, true, "ok", "lnb isw", "channel=" + LnbChannelToSchemaName(channel) + " value=" + IswToText(lowLimit ? 1 : 0));
                 }
                 else

--- a/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
@@ -12,10 +12,17 @@ namespace CubleyControl
     public static partial class Program
     {
         private const int MqttSubscriptionFailure = 0x80;
-        private const int MqttCommandIdMaxLength = 5;
-        private const int MqttCommandEnvelopeMaxLength = MqttCommandMaxLength + MqttCommandIdMaxLength + 1;
+        // Wire contract version; see docs/software/DEVICE_API_V2.md.
+        private const int DeviceContractVersion = 2;
+        private const int MqttCommandIdMaxLength = 32;
+        private const int MqttOpMaxLength = 40;
+        private const int MqttCommandEnvelopeMaxLength = 256;
         private const int MqttDuplicateCacheSize = 8;
-        private const int MqttCachedResponseLimit = 32;
+        // A time bound, not just a slot count: under a slot-only scheme
+        // whether a reused id replayed or conflicted depended on how many
+        // unrelated commands had happened since, which a client cannot see.
+        private const int MqttDedupTtlMs = 120_000;
+        private const int MqttBridgedLineLimit = 16;
         private const int MqttPublishQueueCapacity = 64;
         private const string MqttAvailabilityOnline = "online";
         private const string MqttAvailabilityOffline = "offline";
@@ -29,12 +36,10 @@ namespace CubleyControl
         private static string _mqttRuntimeState = "disabled";
         private static string _mqttLastError = string.Empty;
         private static int _mqttReconnectAttempts;
-        private static readonly ushort[] _mqttCachedCommandIds = new ushort[MqttDuplicateCacheSize];
-        private static readonly bool[] _mqttCachedCommandValid = new bool[MqttDuplicateCacheSize];
-        private static readonly string[] _mqttCachedCommands = new string[MqttDuplicateCacheSize];
-        private static readonly int[] _mqttCachedResponseCounts = new int[MqttDuplicateCacheSize];
-        private static readonly string[] _mqttCachedResponses = new string[MqttDuplicateCacheSize * MqttCachedResponseLimit];
-        private static readonly string[] _mqttActiveResponses = new string[MqttCachedResponseLimit];
+        private static readonly string[] _mqttCachedCommandIds = new string[MqttDuplicateCacheSize];
+        private static readonly string[] _mqttCachedPayloads = new string[MqttDuplicateCacheSize];
+        private static readonly string[] _mqttCachedResponseBodies = new string[MqttDuplicateCacheSize];
+        private static readonly long[] _mqttCachedAtMs = new long[MqttDuplicateCacheSize];
         private static readonly object _mqttCommandTransactionLock = new object();
         private static readonly object _mqttEventLock = new object();
         private static readonly object _mqttPublishQueueLock = new object();
@@ -44,8 +49,14 @@ namespace CubleyControl
         private static readonly bool[] _mqttPublishRetainFlags = new bool[MqttPublishQueueCapacity];
         private static int _mqttDuplicateCacheNext;
         private static int _mqttEventSequence;
-        private static ushort _mqttActiveCommandId;
-        private static int _mqttActiveResponseCount;
+        // Per-command scratch, written only under _commandLock.
+        private static string _mqttActiveCommandKey = "?";
+        private static string _mqttBridgedOutput = string.Empty;
+        private static int _mqttBridgedLineCount;
+        private static bool _mqttResultOk;
+        private static bool _mqttResultRecorded;
+        private static string _mqttResultCode = string.Empty;
+        private static string _mqttResultMsg = string.Empty;
         private static int _mqttPublishQueueHead;
         private static int _mqttPublishQueueCount;
         private static int _mqttPublishDropCount;
@@ -317,147 +328,697 @@ namespace CubleyControl
 
         private static void ProcessMqttCommand(string payload)
         {
-            ushort commandId;
-            string command;
-            if (!TryParseMqttCommandEnvelope(payload, out commandId, out command))
+            JsonObject command;
+            string parseError;
+            if (!Json.TryParseObject(payload, out command, out parseError))
             {
                 WriteStructuredDebug(
                     "COMMAND",
                     "schema=1 sub=command comp=envelope operation=parse stat=error" +
-                    " transport=mqtt code=invalid_envelope");
-                PublishMqttResponse("id=none Fail: invalid command envelope", false);
+                    " transport=mqtt code=invalid_envelope detail=" + SanitizeToken(parseError));
+                PublishMqttFailure("?", "validation_error", parseError);
+                return;
+            }
+
+            int version = DeviceContractVersion;
+            if (command.Has("v") &&
+                (!command.TryGetInt("v", out version) || version != DeviceContractVersion))
+            {
+                PublishMqttFailure(
+                    "?",
+                    "validation_error",
+                    "unsupported contract version; this device speaks v" + DeviceContractVersion.ToString());
+                return;
+            }
+
+            string commandId;
+            if (!command.TryGetString("id", out commandId) || !IsValidMqttCommandId(commandId))
+            {
+                PublishMqttFailure(
+                    "?",
+                    "validation_error",
+                    "id must be 1 to " + MqttCommandIdMaxLength.ToString() + " characters of A-Za-z0-9._:-");
+                return;
+            }
+
+            string op;
+            if (!command.TryGetString("op", out op) || !IsValidMqttOpName(op))
+            {
+                PublishMqttFailure(
+                    commandId,
+                    "validation_error",
+                    "op must be 1 to " + MqttOpMaxLength.ToString() + " characters of a-z0-9._");
                 return;
             }
 
             int cachedIndex = FindCachedMqttCommand(commandId);
             if (cachedIndex >= 0)
             {
-                if (_mqttCachedCommands[cachedIndex] != command)
+                if (_mqttCachedPayloads[cachedIndex] != payload)
                 {
                     WriteStructuredDebug(
                         "COMMAND",
                         "schema=1 sub=command comp=deduplicate operation=reject stat=error" +
-                        " transport=mqtt code=id_conflict id=" + commandId.ToString());
-                    PublishMqttResponse("id=" + commandId.ToString() + " Fail: command id conflict", false);
+                        " transport=mqtt code=id_conflict id=" + SanitizeToken(commandId));
+                    PublishMqttFailure(
+                        commandId,
+                        "id_conflict",
+                        "id reused within the deduplication window with a different payload");
                     return;
                 }
 
                 WriteStructuredDebug(
                     "COMMAND",
                     "schema=1 sub=command comp=deduplicate operation=replay stat=ok" +
-                    " transport=mqtt id=" + commandId.ToString());
-                ReplayCachedMqttResponses(cachedIndex);
+                    " transport=mqtt id=" + SanitizeToken(commandId));
+                PublishMqttResponseBody(_mqttCachedResponseBodies[cachedIndex], true);
                 return;
             }
 
-            _mqttActiveCommandId = commandId;
-            _mqttActiveResponseCount = 0;
+            _mqttActiveCommandKey = commandId;
             WriteStructuredDebug(
                 "COMMAND",
                 "schema=1 sub=command comp=dispatch operation=start stat=ok" +
-                " transport=mqtt id=" + commandId.ToString() +
-                " command=" + SanitizeToken(RedactCommandForLog(command)));
+                " transport=mqtt id=" + SanitizeToken(commandId) +
+                " op=" + SanitizeToken(op));
 
-            ExecuteCommand(command, MqttOutputSink, CommandTransport.Mqtt);
-            CacheMqttCommandResponses(commandId, command);
+            string responseBody = ExecuteMqttOperation(commandId, op, command);
+            CacheMqttCommandResponse(commandId, payload, responseBody);
+            PublishMqttResponseBody(responseBody, false);
             PublishMqttState();
             PublishMqttDiseqcState();
+
             WriteStructuredDebug(
                 "COMMAND",
                 "schema=1 sub=command comp=dispatch operation=complete stat=ok" +
-                " transport=mqtt id=" + commandId.ToString());
+                " transport=mqtt id=" + SanitizeToken(commandId));
+        }
+
+        private static string ExecuteMqttOperation(string commandId, string op, JsonObject command)
+        {
+            if (op == "positioner.goto" || op == "positioner.step" ||
+                op == "positioner.drive" || op == "positioner.halt")
+            {
+                return ExecuteMqttPositionerMotion(commandId, op, command);
+            }
+
+            if (op == "positioner.show" || op == "positioner.job" || op == "positioner.release")
+            {
+                return ExecuteMqttPositionerQuery(commandId, op, command);
+            }
+
+            return ExecuteMqttBridgedOperation(commandId, op, command);
+        }
+
+        /// <summary>
+        /// Motion operations are dispatched with typed parameters straight to
+        /// the shared hardware path -- they never build a console command
+        /// string. This is the parse/execute split described in
+        /// docs/software/DEVICE_API_V2.md; the bridged operations below are
+        /// the migration remainder.
+        /// </summary>
+        private static string ExecuteMqttPositionerMotion(string commandId, string op, JsonObject command)
+        {
+            int operation;
+            int value = 0;
+            string error;
+
+            if (op == "positioner.goto")
+            {
+                if (!TryValidateMqttMembers(command, "position", null, out error))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+                }
+
+                int position;
+                if (!command.TryGetInt("position", out position) || position < 0 || position > 255)
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", "position must be an integer 0 to 255", 0);
+                }
+
+                operation = PositionerOpGoto;
+                value = position;
+            }
+            else if (op == "positioner.step")
+            {
+                if (!TryValidateMqttMembers(command, "direction", "count", out error))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+                }
+
+                string direction;
+                if (!command.TryGetString("direction", out direction) ||
+                    (direction != "east" && direction != "west"))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", "direction must be \"east\" or \"west\"", 0);
+                }
+
+                int count;
+                if (!command.TryGetInt("count", out count) || count < 1 || count > 128)
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", "count must be an integer 1 to 128", 0);
+                }
+
+                operation = direction == "east" ? PositionerOpStepEast : PositionerOpStepWest;
+                value = count;
+            }
+            else if (op == "positioner.drive")
+            {
+                if (!TryValidateMqttMembers(command, "direction", null, out error))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+                }
+
+                string direction;
+                if (!command.TryGetString("direction", out direction) ||
+                    (direction != "east" && direction != "west"))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", "direction must be \"east\" or \"west\"", 0);
+                }
+
+                operation = direction == "east" ? PositionerOpDriveEast : PositionerOpDriveWest;
+            }
+            else
+            {
+                if (!TryValidateMqttMembers(command, null, null, out error))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+                }
+
+                operation = PositionerOpHalt;
+            }
+
+            ResetMqttCommandOutcome();
+            ExecutePositionerOperation(operation, value, MqttOutputSink);
+
+            if (!_mqttResultOk)
+            {
+                return BuildMqttFailureBody(
+                    commandId,
+                    _mqttResultCode.Length == 0 ? "hw_fault" : _mqttResultCode,
+                    _mqttResultMsg,
+                    _blockingDiseqcJobId);
+            }
+
+            int jobId = _lastStartedDiseqcJobId;
+            bool started = jobId != 0 && GetActiveDiseqcJobId() == jobId;
+            return BuildMqttResponseBody(
+                commandId,
+                true,
+                started ? "accepted" : "ok",
+                null,
+                started ? null : BuildDiseqcStateJson(),
+                jobId,
+                null);
+        }
+
+        private static string ExecuteMqttPositionerQuery(string commandId, string op, JsonObject command)
+        {
+            string error;
+
+            if (op == "positioner.show")
+            {
+                if (!TryValidateMqttMembers(command, null, null, out error))
+                {
+                    return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+                }
+
+                return BuildMqttResponseBody(commandId, true, "ok", null, BuildDiseqcStateJson(), 0, null);
+            }
+
+            if (!TryValidateMqttMembers(command, "job", null, out error))
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+            }
+
+            int jobId;
+            if (!command.TryGetInt("job", out jobId) || jobId <= 0)
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", "job must be a positive integer", 0);
+            }
+
+            string jobJson = BuildDiseqcJobJson(jobId);
+            if (jobJson == "null")
+            {
+                return BuildMqttFailureBody(commandId, "not_found", "unknown or evicted job", 0);
+            }
+
+            if (op == "positioner.job")
+            {
+                return BuildMqttResponseBody(commandId, true, "ok", null, jobJson, jobId, null);
+            }
+
+            // positioner.release: the identity check inside TryEndDiseqcJob is
+            // what stops a late release from ending a newer movement.
+            if (!TryEndDiseqcJob(jobId, JobStateReleased, string.Empty))
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", "job is not the running job", GetActiveDiseqcJobId());
+            }
+
+            PublishMqttDiseqcJobTransition("end", jobId);
+            return BuildMqttResponseBody(commandId, true, "ok", null, BuildDiseqcJobJson(jobId), jobId, null);
+        }
+
+        /// <summary>
+        /// Migration path: these operations are still executed by the console
+        /// tokenizer and return console text in "lines". Every parameter is
+        /// charset-checked before it reaches the command string, so a value
+        /// can never introduce an extra token.
+        /// </summary>
+        private static string ExecuteMqttBridgedOperation(string commandId, string op, JsonObject command)
+        {
+            string consoleCommand;
+            string code;
+            string error;
+            if (!TryBuildBridgedConsoleCommand(op, command, out consoleCommand, out code, out error))
+            {
+                return BuildMqttFailureBody(commandId, code, error, 0);
+            }
+
+            ResetMqttCommandOutcome();
+            ExecuteCommand(consoleCommand, MqttOutputSink, CommandTransport.Mqtt);
+
+            if (!_mqttResultRecorded)
+            {
+                return BuildMqttResponseBody(commandId, true, "ok", null, null, 0, _mqttBridgedOutput);
+            }
+
+            return BuildMqttResponseBody(
+                commandId,
+                _mqttResultOk,
+                _mqttResultOk ? "ok" : (_mqttResultCode.Length == 0 ? "hw_fault" : _mqttResultCode),
+                _mqttResultOk ? null : _mqttResultMsg,
+                null,
+                0,
+                _mqttBridgedOutput);
+        }
+
+        private static bool TryBuildBridgedConsoleCommand(
+            string op,
+            JsonObject command,
+            out string consoleCommand,
+            out string code,
+            out string error)
+        {
+            consoleCommand = string.Empty;
+            code = "validation_error";
+            error = string.Empty;
+
+            if (op == "system.status" || op == "system.version" || op == "system.capabilities")
+            {
+                if (!TryValidateMqttMembers(command, null, null, out error))
+                {
+                    return false;
+                }
+
+                consoleCommand = op == "system.status" ? "status" : (op == "system.version" ? "version" : "capabilities");
+                return true;
+            }
+
+            if (op == "diseqc.show")
+            {
+                if (!TryValidateMqttMembers(command, null, null, out error))
+                {
+                    return false;
+                }
+
+                consoleCommand = "show diseqc";
+                return true;
+            }
+
+            if (op == "lnb.show")
+            {
+                if (!TryValidateMqttMembers(command, "channel", null, out error))
+                {
+                    return false;
+                }
+
+                consoleCommand = "show lnb";
+                if (command.Has("channel"))
+                {
+                    string channel;
+                    if (!TryReadLnbChannel(command, out channel, out error))
+                    {
+                        return false;
+                    }
+
+                    consoleCommand += " " + channel;
+                }
+
+                return true;
+            }
+
+            if (op == "lnb.enable" || op == "lnb.disable")
+            {
+                if (!TryValidateMqttMembers(command, "channel", null, out error))
+                {
+                    return false;
+                }
+
+                string channel;
+                if (!TryReadLnbChannel(command, out channel, out error))
+                {
+                    return false;
+                }
+
+                consoleCommand = "lnb " + channel + (op == "lnb.enable" ? " enable" : " disable");
+                return true;
+            }
+
+            if (op == "lnb.polarization" || op == "lnb.band")
+            {
+                if (!TryValidateMqttMembers(command, "channel", "value", out error))
+                {
+                    return false;
+                }
+
+                string channel;
+                if (!TryReadLnbChannel(command, out channel, out error))
+                {
+                    return false;
+                }
+
+                string value;
+                if (!command.TryGetString("value", out value) || !IsSafeConsoleToken(value))
+                {
+                    error = "value must be 1 to 16 characters of a-z0-9";
+                    return false;
+                }
+
+                consoleCommand = "lnb " + channel +
+                    (op == "lnb.polarization" ? " polarization " : " band ") + value;
+                return true;
+            }
+
+            if (op == "diseqc.preset" || op == "diseqc.tone")
+            {
+                if (!TryValidateMqttMembers(command, "value", null, out error))
+                {
+                    return false;
+                }
+
+                string value;
+                if (!command.TryGetString("value", out value) || !IsSafeConsoleToken(value))
+                {
+                    error = "value must be 1 to 16 characters of a-z0-9";
+                    return false;
+                }
+
+                consoleCommand = (op == "diseqc.preset" ? "diseqc preset " : "diseqc tone ") + value;
+                return true;
+            }
+
+            if (op == "diseqc.tx")
+            {
+                if (!TryValidateMqttMembers(command, "frame", null, out error))
+                {
+                    return false;
+                }
+
+                string frame;
+                if (!command.TryGetString("frame", out frame) ||
+                    frame.Length < 2 || frame.Length > 12 || (frame.Length % 2) != 0)
+                {
+                    error = "frame must be a hex string of 1 to 6 bytes";
+                    return false;
+                }
+
+                string spaced = string.Empty;
+                for (int index = 0; index < frame.Length; index += 2)
+                {
+                    int ignored;
+                    string pair = frame.Substring(index, 2);
+                    if (!TryParseByteHex(pair, out ignored))
+                    {
+                        error = "frame must be a hex string of 1 to 6 bytes";
+                        return false;
+                    }
+
+                    spaced += (index == 0 ? string.Empty : " ") + pair;
+                }
+
+                consoleCommand = "diseqc tx " + spaced;
+                return true;
+            }
+
+            code = "unsupported";
+            error = "unknown operation";
+            return false;
+        }
+
+        private static bool TryReadLnbChannel(JsonObject command, out string channel, out string error)
+        {
+            error = string.Empty;
+            if (!command.TryGetString("channel", out channel) ||
+                (channel != "a" && channel != "b"))
+            {
+                channel = string.Empty;
+                error = "channel must be \"a\" or \"b\"";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Unknown members are rejected rather than ignored, so a typo fails
+        /// loudly instead of silently doing something else to a motor.
+        /// </summary>
+        private static bool TryValidateMqttMembers(JsonObject command, string first, string second, out string error)
+        {
+            for (int index = 0; index < command.Count; index++)
+            {
+                string key = command.KeyAt(index);
+                if (key == "v" || key == "id" || key == "op")
+                {
+                    continue;
+                }
+
+                if (first != null && key == first)
+                {
+                    continue;
+                }
+
+                if (second != null && key == second)
+                {
+                    continue;
+                }
+
+                error = "unknown member " + key;
+                return false;
+            }
+
+            error = string.Empty;
+            return true;
+        }
+
+        private static bool IsValidMqttCommandId(string value)
+        {
+            if (value == null || value.Length == 0 || value.Length > MqttCommandIdMaxLength)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < value.Length; index++)
+            {
+                char current = value[index];
+                bool allowed =
+                    (current >= 'a' && current <= 'z') ||
+                    (current >= 'A' && current <= 'Z') ||
+                    (current >= '0' && current <= '9') ||
+                    current == '.' || current == '_' || current == ':' || current == '-';
+                if (!allowed)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsValidMqttOpName(string value)
+        {
+            if (value == null || value.Length == 0 || value.Length > MqttOpMaxLength)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < value.Length; index++)
+            {
+                char current = value[index];
+                bool allowed =
+                    (current >= 'a' && current <= 'z') ||
+                    (current >= '0' && current <= '9') ||
+                    current == '.' || current == '_';
+                if (!allowed)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsSafeConsoleToken(string value)
+        {
+            if (value == null || value.Length == 0 || value.Length > 16)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < value.Length; index++)
+            {
+                char current = value[index];
+                if (!((current >= 'a' && current <= 'z') || (current >= '0' && current <= '9')))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static void ResetMqttCommandOutcome()
+        {
+            _mqttResultOk = false;
+            _mqttResultRecorded = false;
+            _mqttResultCode = string.Empty;
+            _mqttResultMsg = string.Empty;
+            _mqttBridgedOutput = string.Empty;
+            _mqttBridgedLineCount = 0;
+            ResetDiseqcJobCommandScratch();
+        }
+
+        /// <summary>
+        /// Captures a command outcome instead of writing it to the transport,
+        /// so the JSON layer can emit exactly one structured response per
+        /// command rather than one message per console line.
+        /// </summary>
+        private static void RecordMqttCommandOutcome(bool ok, string code, string msg)
+        {
+            _mqttResultOk = ok;
+            _mqttResultCode = code == null ? string.Empty : code;
+            _mqttResultMsg = msg == null ? string.Empty : msg;
+            _mqttResultRecorded = true;
         }
 
         private static void MqttOutputSink(string line)
         {
-            string payload = "id=" + _mqttActiveCommandId.ToString() + " " + line.TrimEnd('\r', '\n');
-            if (_mqttActiveResponseCount < MqttCachedResponseLimit)
+            if (line == null || _mqttBridgedLineCount >= MqttBridgedLineLimit)
             {
-                _mqttActiveResponses[_mqttActiveResponseCount++] = payload;
+                return;
             }
 
-            PublishMqttResponse(payload, false);
+            string trimmed = line.TrimEnd('\r', '\n');
+            if (trimmed.Length == 0)
+            {
+                return;
+            }
+
+            _mqttBridgedOutput = _mqttBridgedLineCount == 0
+                ? trimmed
+                : _mqttBridgedOutput + "\n" + trimmed;
+            _mqttBridgedLineCount++;
         }
 
-        private static bool TryParseMqttCommandEnvelope(string payload, out ushort commandId, out string command)
+        private static string BuildMqttFailureBody(string commandId, string code, string msg, int jobId)
         {
-            commandId = 0;
-            command = string.Empty;
-
-            int separator = payload.IndexOf(' ');
-            if (separator < 1 || separator > MqttCommandIdMaxLength || separator == payload.Length - 1)
-            {
-                return false;
-            }
-
-            int parsedId;
-            if (!int.TryParse(payload.Substring(0, separator), out parsedId) || parsedId < 0 || parsedId > ushort.MaxValue)
-            {
-                return false;
-            }
-
-            command = payload.Substring(separator + 1).Trim();
-            if (command.Length == 0 || command.Length > MqttCommandMaxLength)
-            {
-                return false;
-            }
-
-            commandId = (ushort)parsedId;
-            return true;
+            return BuildMqttResponseBody(commandId, false, code, msg, null, jobId, null);
         }
 
-        private static int FindCachedMqttCommand(ushort commandId)
+        private static string BuildMqttResponseBody(
+            string commandId,
+            bool ok,
+            string code,
+            string msg,
+            string dataRaw,
+            int jobId,
+            string lines)
         {
+            JsonBuilder builder = new JsonBuilder()
+                .AddInt("v", DeviceContractVersion)
+                .AddString("id", commandId)
+                .AddBool("ok", ok)
+                .AddString("code", code)
+                .AddLong("ts_ms", Environment.TickCount64);
+
+            if (msg != null && msg.Length > 0)
+            {
+                builder.AddString("msg", msg);
+            }
+
+            if (jobId != 0)
+            {
+                builder.AddInt("job", jobId);
+            }
+
+            if (dataRaw != null)
+            {
+                builder.AddRaw("data", dataRaw);
+            }
+
+            if (lines != null && lines.Length > 0)
+            {
+                builder.AddString("lines", lines);
+            }
+
+            return builder.BuildBody();
+        }
+
+        private static void PublishMqttFailure(string commandId, string code, string msg)
+        {
+            PublishMqttResponseBody(BuildMqttFailureBody(commandId, code, msg, 0), false);
+        }
+
+        private static void PublishMqttResponseBody(string responseBody, bool replayed)
+        {
+            string payload = replayed
+                ? "{" + responseBody + ",\"replayed\":true}"
+                : "{" + responseBody + "}";
+
+            WriteStructuredDebug(
+                "COMMAND",
+                "schema=1 sub=command comp=response operation=publish stat=ok" +
+                " transport=mqtt topic=" + _mqttResponseTopic +
+                " duplicate=" + (replayed ? "1" : "0") +
+                " payload=" + SanitizeToken(payload));
+            QueueMqttPublication(_mqttResponseTopic, payload, MqttQoSLevel.AtLeastOnce, false);
+        }
+
+        private static int FindCachedMqttCommand(string commandId)
+        {
+            long nowMs = Environment.TickCount64;
             for (int index = 0; index < MqttDuplicateCacheSize; index++)
             {
-                if (_mqttCachedCommandValid[index] && _mqttCachedCommandIds[index] == commandId)
+                if (_mqttCachedCommandIds[index] == null || _mqttCachedCommandIds[index] != commandId)
                 {
-                    return index;
+                    continue;
                 }
+
+                if (nowMs - _mqttCachedAtMs[index] > MqttDedupTtlMs)
+                {
+                    _mqttCachedCommandIds[index] = null;
+                    _mqttCachedPayloads[index] = null;
+                    _mqttCachedResponseBodies[index] = null;
+                    return -1;
+                }
+
+                return index;
             }
 
             return -1;
         }
 
-        private static void CacheMqttCommandResponses(ushort commandId, string command)
+        private static void CacheMqttCommandResponse(string commandId, string payload, string responseBody)
         {
-            int cacheIndex = _mqttDuplicateCacheNext;
-            int responseOffset = cacheIndex * MqttCachedResponseLimit;
-            int responseCount = _mqttActiveResponseCount;
-
-            for (int index = 0; index < MqttCachedResponseLimit; index++)
-            {
-                _mqttCachedResponses[responseOffset + index] = index < responseCount ? _mqttActiveResponses[index] : null;
-                _mqttActiveResponses[index] = null;
-            }
-
-            _mqttCachedCommandIds[cacheIndex] = commandId;
-            _mqttCachedCommands[cacheIndex] = command;
-            _mqttCachedResponseCounts[cacheIndex] = responseCount;
-            _mqttCachedCommandValid[cacheIndex] = true;
-            _mqttDuplicateCacheNext = (cacheIndex + 1) % MqttDuplicateCacheSize;
+            int slot = _mqttDuplicateCacheNext;
+            _mqttCachedCommandIds[slot] = commandId;
+            _mqttCachedPayloads[slot] = payload;
+            _mqttCachedResponseBodies[slot] = responseBody;
+            _mqttCachedAtMs[slot] = Environment.TickCount64;
+            _mqttDuplicateCacheNext = (slot + 1) % MqttDuplicateCacheSize;
         }
 
-        private static void ReplayCachedMqttResponses(int cacheIndex)
-        {
-            int responseOffset = cacheIndex * MqttCachedResponseLimit;
-            int responseCount = _mqttCachedResponseCounts[cacheIndex];
-            for (int index = 0; index < responseCount; index++)
-            {
-                PublishMqttResponse(_mqttCachedResponses[responseOffset + index], true);
-            }
-        }
-
-        private static void PublishMqttResponse(string payload, bool duplicate)
-        {
-            WriteStructuredDebug(
-                "COMMAND",
-                "schema=1 sub=command comp=response operation=publish stat=ok" +
-                " transport=mqtt topic=" + _mqttResponseTopic +
-                " duplicate=" + (duplicate ? "1" : "0") +
-                " payload=" + SanitizeToken(payload));
-            QueueMqttPublication(_mqttResponseTopic, payload, MqttQoSLevel.AtLeastOnce, false);
-        }
 
         private static void PublishMqttLnbFaultTransition(bool active, string source)
         {
@@ -537,49 +1098,17 @@ namespace CubleyControl
             QueueMqttPublication(_mqttStateTopic, payload, MqttQoSLevel.AtLeastOnce, true);
         }
 
-        private static void PublishMqttDiseqcMotionTransition(string transition)
+        private static void PublishMqttDiseqcJobTransition(string transition, int jobId)
         {
-            bool busy;
-            int motionId;
-            string operation;
-            int remainingMs;
-            string completionSource;
-            GetDiseqcMotionSnapshot(out busy, out motionId, out operation, out remainingMs, out completionSource);
-
-            string payload =
-                "schema=1 sub=diseqc comp=motion" +
-                " operation=" + transition +
-                " stat=" + (busy ? "busy" : "idle") +
-                " event_id=" + NextMqttEventId().ToString() +
-                " motion_id=" + motionId.ToString() +
-                " motion_operation=" + operation +
-                " remaining_ms=" + remainingMs.ToString() +
-                " completion=" + completionSource;
-
+            string payload = BuildDiseqcJobEventJson(transition, jobId);
             WriteStructuredDebug("DISEQC", payload);
             QueueMqttPublication(_mqttDiseqcEventTopic, payload, MqttQoSLevel.AtLeastOnce, false);
-
             PublishMqttDiseqcState();
         }
 
         private static void PublishMqttDiseqcState()
         {
-            bool busy;
-            int motionId;
-            string operation;
-            int remainingMs;
-            string completionSource;
-            GetDiseqcMotionSnapshot(out busy, out motionId, out operation, out remainingMs, out completionSource);
-
-            string payload =
-                "schema=1 sub=diseqc comp=state" +
-                " stat=" + (busy ? "busy" : "idle") +
-                " motion_id=" + motionId.ToString() +
-                " operation=" + operation +
-                " remaining_ms=" + remainingMs.ToString() +
-                " completion=" + completionSource +
-                " timeout_ms=" + _diseqcMotionTimeoutMs.ToString();
-
+            string payload = BuildDiseqcStateJson();
             WriteStructuredDebug("DISEQC", payload);
             QueueMqttPublication(_mqttDiseqcStateTopic, payload, MqttQoSLevel.AtLeastOnce, true);
         }

--- a/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
@@ -11,7 +11,6 @@ namespace CubleyControl
 {
     public static partial class Program
     {
-        private const int MqttSubscriptionFailure = 0x80;
         // Wire contract version; see docs/software/DEVICE_API_V2.md.
         private const int DeviceContractVersion = 2;
         private const int MqttCommandIdMaxLength = 32;
@@ -27,8 +26,6 @@ namespace CubleyControl
         private const string MqttAvailabilityOnline = "online";
         private const string MqttAvailabilityOffline = "offline";
         private static MqttClient _mqttClient;
-        private static string _mqttCommandTopic = string.Empty;
-        private static string _mqttResponseTopic = string.Empty;
         private static string _mqttEventTopic = string.Empty;
         private static string _mqttStateTopic = string.Empty;
         private static string _mqttDiseqcEventTopic = string.Empty;
@@ -118,8 +115,6 @@ namespace CubleyControl
         {
             string topicRoot = BuildMqttTopicRoot(configuration);
             string availabilityTopic = topicRoot + "/availability";
-            _mqttCommandTopic = topicRoot + "/command";
-            _mqttResponseTopic = topicRoot + "/response";
             _mqttEventTopic = topicRoot + "/event/lnb";
             _mqttStateTopic = topicRoot + "/state/lnb";
             _mqttDiseqcEventTopic = topicRoot + "/event/diseqc";
@@ -129,8 +124,6 @@ namespace CubleyControl
 
             _mqttClient = new MqttClient(configuration.Broker, configuration.Port, false, null, null, MqttSslProtocols.None);
             _mqttClient.ProtocolVersion = MqttProtocolVersion.Version_3_1_1;
-            _mqttClient.MqttMsgPublishReceived += OnMqttMessageReceived;
-            _mqttClient.MqttMsgSubscribed += OnMqttSubscribed;
             _mqttClient.ConnectionClosed += OnMqttConnectionClosed;
 
             try
@@ -176,16 +169,6 @@ namespace CubleyControl
                     return;
                 }
 
-                _mqttRuntimeState = "subscribing";
-                ushort subscriptionMessageId = _mqttClient.Subscribe(
-                    new string[] { _mqttCommandTopic },
-                    new MqttQoSLevel[] { MqttQoSLevel.AtLeastOnce });
-                WriteStructuredDebug(
-                    "MQTT",
-                    "schema=1 sub=mqtt comp=subscribe operation=request stat=pending" +
-                    " topic=" + _mqttCommandTopic +
-                    " qos=1 message_id=" + subscriptionMessageId.ToString());
-
                 while (_mqttClient.IsConnected &&
                     revision == _mqttConfigurationRevision &&
                     _mqttRuntimeState != "error")
@@ -208,16 +191,12 @@ namespace CubleyControl
                 SetMqttPublishAccepting(false);
                 MqttClient client = _mqttClient;
                 _mqttClient = null;
-                _mqttCommandTopic = string.Empty;
-                _mqttResponseTopic = string.Empty;
                 _mqttEventTopic = string.Empty;
                 _mqttStateTopic = string.Empty;
                 _mqttDiseqcEventTopic = string.Empty;
                 _mqttDiseqcStateTopic = string.Empty;
                 if (client != null)
                 {
-                    client.MqttMsgPublishReceived -= OnMqttMessageReceived;
-                    client.MqttMsgSubscribed -= OnMqttSubscribed;
                     client.ConnectionClosed -= OnMqttConnectionClosed;
                     TryDisconnectMqttClient(client);
                     try
@@ -233,32 +212,6 @@ namespace CubleyControl
                     }
                 }
             }
-        }
-
-        private static void OnMqttSubscribed(object sender, MqttMsgSubscribedEventArgs e)
-        {
-            MqttQoSLevel[] grantedQosLevels = e.GrantedQoSLevels;
-            if (grantedQosLevels == null ||
-                grantedQosLevels.Length == 0 ||
-                (int)grantedQosLevels[0] == MqttSubscriptionFailure)
-            {
-                _mqttLastError = "subscribe_rejected";
-                _mqttRuntimeState = "error";
-                WriteStructuredDebug(
-                    "MQTT",
-                    "schema=1 sub=mqtt comp=subscribe operation=ack stat=error" +
-                    " code=subscribe_rejected message_id=" + e.MessageId.ToString());
-                return;
-            }
-
-            _mqttLastError = string.Empty;
-            _mqttRuntimeState = "connected";
-            WriteStructuredDebug(
-                "MQTT",
-                "schema=1 sub=mqtt comp=subscribe operation=ack stat=ok" +
-                " topic=" + _mqttCommandTopic +
-                " qos=" + ((int)grantedQosLevels[0]).ToString() +
-                " message_id=" + e.MessageId.ToString());
         }
 
         private static void TryDisconnectMqttClient(MqttClient client)
@@ -281,52 +234,7 @@ namespace CubleyControl
             }
         }
 
-        private static void OnMqttMessageReceived(object sender, MqttMsgPublishEventArgs e)
-        {
-            int payloadLength = e.Message == null ? 0 : e.Message.Length;
-            WriteStructuredDebug(
-                "COMMAND",
-                "schema=1 sub=command comp=receive operation=decode stat=ok transport=mqtt" +
-                " topic=" + e.Topic +
-                " qos=" + ((int)e.QosLevel).ToString() +
-                " retained=" + (e.Retain ? "1" : "0") +
-                " length=" + payloadLength.ToString());
-
-            if (e.Topic != _mqttCommandTopic)
-            {
-                WriteStructuredDebug(
-                    "COMMAND",
-                    "schema=1 sub=command comp=receive operation=reject stat=error" +
-                    " transport=mqtt code=unexpected_topic topic=" + e.Topic);
-                return;
-            }
-
-            if (e.Retain)
-            {
-                WriteStructuredDebug(
-                    "COMMAND",
-                    "schema=1 sub=command comp=receive operation=reject stat=error" +
-                    " transport=mqtt code=retained_command");
-                return;
-            }
-
-            if (e.Message == null || e.Message.Length == 0 || e.Message.Length > MqttCommandEnvelopeMaxLength)
-            {
-                WriteStructuredDebug(
-                    "COMMAND",
-                    "schema=1 sub=command comp=receive operation=reject stat=error" +
-                    " transport=mqtt code=invalid_length length=" + payloadLength.ToString());
-                return;
-            }
-
-            string payload = AsciiBytesToString(e.Message);
-            lock (_mqttCommandTransactionLock)
-            {
-                ProcessMqttCommand(payload);
-            }
-        }
-
-        private static void ProcessMqttCommand(string payload)
+        private static string ProcessApiCommand(string payload)
         {
             JsonObject command;
             string parseError;
@@ -335,40 +243,39 @@ namespace CubleyControl
                 WriteStructuredDebug(
                     "COMMAND",
                     "schema=1 sub=command comp=envelope operation=parse stat=error" +
-                    " transport=mqtt code=invalid_envelope detail=" + SanitizeToken(parseError));
-                PublishMqttFailure("?", "validation_error", parseError);
-                return;
+                    " transport=rest code=invalid_envelope detail=" + SanitizeToken(parseError));
+                return "{" + BuildMqttFailureBody("?", "validation_error", parseError, 0) + "}";
             }
 
             int version = DeviceContractVersion;
             if (command.Has("v") &&
                 (!command.TryGetInt("v", out version) || version != DeviceContractVersion))
             {
-                PublishMqttFailure(
+                return "{" + BuildMqttFailureBody(
                     "?",
                     "validation_error",
-                    "unsupported contract version; this device speaks v" + DeviceContractVersion.ToString());
-                return;
+                    "unsupported contract version; this device speaks v" + DeviceContractVersion.ToString(),
+                    0) + "}";
             }
 
             string commandId;
             if (!command.TryGetString("id", out commandId) || !IsValidMqttCommandId(commandId))
             {
-                PublishMqttFailure(
+                return "{" + BuildMqttFailureBody(
                     "?",
                     "validation_error",
-                    "id must be 1 to " + MqttCommandIdMaxLength.ToString() + " characters of A-Za-z0-9._:-");
-                return;
+                    "id must be 1 to " + MqttCommandIdMaxLength.ToString() + " characters of A-Za-z0-9._:-",
+                    0) + "}";
             }
 
             string op;
             if (!command.TryGetString("op", out op) || !IsValidMqttOpName(op))
             {
-                PublishMqttFailure(
+                return "{" + BuildMqttFailureBody(
                     commandId,
                     "validation_error",
-                    "op must be 1 to " + MqttOpMaxLength.ToString() + " characters of a-z0-9._");
-                return;
+                    "op must be 1 to " + MqttOpMaxLength.ToString() + " characters of a-z0-9._",
+                    0) + "}";
             }
 
             int cachedIndex = FindCachedMqttCommand(commandId);
@@ -379,39 +286,36 @@ namespace CubleyControl
                     WriteStructuredDebug(
                         "COMMAND",
                         "schema=1 sub=command comp=deduplicate operation=reject stat=error" +
-                        " transport=mqtt code=id_conflict id=" + SanitizeToken(commandId));
-                    PublishMqttFailure(
+                        " transport=rest code=id_conflict id=" + SanitizeToken(commandId));
+                    return "{" + BuildMqttFailureBody(
                         commandId,
                         "id_conflict",
-                        "id reused within the deduplication window with a different payload");
-                    return;
+                        "id reused within the deduplication window with a different payload",
+                        0) + "}";
                 }
 
                 WriteStructuredDebug(
                     "COMMAND",
                     "schema=1 sub=command comp=deduplicate operation=replay stat=ok" +
-                    " transport=mqtt id=" + SanitizeToken(commandId));
-                PublishMqttResponseBody(_mqttCachedResponseBodies[cachedIndex], true);
-                return;
+                    " transport=rest id=" + SanitizeToken(commandId));
+                return "{" + _mqttCachedResponseBodies[cachedIndex] + ",\"replayed\":true}";
             }
 
             _mqttActiveCommandKey = commandId;
             WriteStructuredDebug(
                 "COMMAND",
                 "schema=1 sub=command comp=dispatch operation=start stat=ok" +
-                " transport=mqtt id=" + SanitizeToken(commandId) +
+                " transport=rest id=" + SanitizeToken(commandId) +
                 " op=" + SanitizeToken(op));
 
             string responseBody = ExecuteMqttOperation(commandId, op, command);
             CacheMqttCommandResponse(commandId, payload, responseBody);
-            PublishMqttResponseBody(responseBody, false);
-            PublishMqttState();
-            PublishMqttDiseqcState();
 
             WriteStructuredDebug(
                 "COMMAND",
                 "schema=1 sub=command comp=dispatch operation=complete stat=ok" +
-                " transport=mqtt id=" + SanitizeToken(commandId));
+                " transport=rest id=" + SanitizeToken(commandId));
+            return "{" + responseBody + "}";
         }
 
         private static string ExecuteMqttOperation(string commandId, string op, JsonObject command)
@@ -422,7 +326,7 @@ namespace CubleyControl
                 return ExecuteMqttPositionerMotion(commandId, op, command);
             }
 
-            if (op == "positioner.show" || op == "positioner.job" || op == "positioner.release")
+            if (op == "positioner.release")
             {
                 return ExecuteMqttPositionerQuery(commandId, op, command);
             }
@@ -536,16 +440,6 @@ namespace CubleyControl
         {
             string error;
 
-            if (op == "positioner.show")
-            {
-                if (!TryValidateMqttMembers(command, null, null, out error))
-                {
-                    return BuildMqttFailureBody(commandId, "validation_error", error, 0);
-                }
-
-                return BuildMqttResponseBody(commandId, true, "ok", null, BuildDiseqcStateJson(), 0, null);
-            }
-
             if (!TryValidateMqttMembers(command, "job", null, out error))
             {
                 return BuildMqttFailureBody(commandId, "validation_error", error, 0);
@@ -555,17 +449,6 @@ namespace CubleyControl
             if (!command.TryGetInt("job", out jobId) || jobId <= 0)
             {
                 return BuildMqttFailureBody(commandId, "validation_error", "job must be a positive integer", 0);
-            }
-
-            string jobJson = BuildDiseqcJobJson(jobId);
-            if (jobJson == "null")
-            {
-                return BuildMqttFailureBody(commandId, "not_found", "unknown or evicted job", 0);
-            }
-
-            if (op == "positioner.job")
-            {
-                return BuildMqttResponseBody(commandId, true, "ok", null, jobJson, jobId, null);
             }
 
             // positioner.release: the identity check inside TryEndDiseqcJob is
@@ -596,7 +479,7 @@ namespace CubleyControl
             }
 
             ResetMqttCommandOutcome();
-            ExecuteCommand(consoleCommand, MqttOutputSink, CommandTransport.Mqtt);
+            ExecuteCommand(consoleCommand, MqttOutputSink, CommandTransport.Rest);
 
             if (!_mqttResultRecorded)
             {
@@ -623,50 +506,6 @@ namespace CubleyControl
             consoleCommand = string.Empty;
             code = "validation_error";
             error = string.Empty;
-
-            if (op == "system.status" || op == "system.version" || op == "system.capabilities")
-            {
-                if (!TryValidateMqttMembers(command, null, null, out error))
-                {
-                    return false;
-                }
-
-                consoleCommand = op == "system.status" ? "status" : (op == "system.version" ? "version" : "capabilities");
-                return true;
-            }
-
-            if (op == "diseqc.show")
-            {
-                if (!TryValidateMqttMembers(command, null, null, out error))
-                {
-                    return false;
-                }
-
-                consoleCommand = "show diseqc";
-                return true;
-            }
-
-            if (op == "lnb.show")
-            {
-                if (!TryValidateMqttMembers(command, "channel", null, out error))
-                {
-                    return false;
-                }
-
-                consoleCommand = "show lnb";
-                if (command.Has("channel"))
-                {
-                    string channel;
-                    if (!TryReadLnbChannel(command, out channel, out error))
-                    {
-                        return false;
-                    }
-
-                    consoleCommand += " " + channel;
-                }
-
-                return true;
-            }
 
             if (op == "lnb.enable" || op == "lnb.disable")
             {
@@ -963,26 +802,6 @@ namespace CubleyControl
             }
 
             return builder.BuildBody();
-        }
-
-        private static void PublishMqttFailure(string commandId, string code, string msg)
-        {
-            PublishMqttResponseBody(BuildMqttFailureBody(commandId, code, msg, 0), false);
-        }
-
-        private static void PublishMqttResponseBody(string responseBody, bool replayed)
-        {
-            string payload = replayed
-                ? "{" + responseBody + ",\"replayed\":true}"
-                : "{" + responseBody + "}";
-
-            WriteStructuredDebug(
-                "COMMAND",
-                "schema=1 sub=command comp=response operation=publish stat=ok" +
-                " transport=mqtt topic=" + _mqttResponseTopic +
-                " duplicate=" + (replayed ? "1" : "0") +
-                " payload=" + SanitizeToken(payload));
-            QueueMqttPublication(_mqttResponseTopic, payload, MqttQoSLevel.AtLeastOnce, false);
         }
 
         private static int FindCachedMqttCommand(string commandId)

--- a/software/nanoFramework/CubleyControl/Program.Commands.Rest.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Rest.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace CubleyControl
+{
+    public static partial class Program
+    {
+        private const int RestPort = 80;
+        private const string RestCommandPath = "/api/v2/commands";
+        private const int RestHeaderMaxLength = 768;
+        private const int RestSocketTimeoutMs = 2000;
+
+        private static void RestLoop()
+        {
+            while (true)
+            {
+                if (!HasUsableIpv4Address())
+                {
+                    Thread.Sleep(1000);
+                    continue;
+                }
+
+                Socket listener = null;
+                try
+                {
+                    listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                    listener.Bind(new IPEndPoint(IPAddress.Any, RestPort));
+                    listener.Listen(2);
+                    WriteStructuredDebug(
+                        "REST",
+                        "schema=1 sub=rest comp=server operation=listen stat=ok port=" + RestPort.ToString());
+
+                    while (true)
+                    {
+                        Socket client = listener.Accept();
+                        try
+                        {
+                            client.ReceiveTimeout = RestSocketTimeoutMs;
+                            client.SendTimeout = RestSocketTimeoutMs;
+                            HandleRestRequest(client);
+                        }
+                        finally
+                        {
+                            client.Close();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WriteStructuredDebug(
+                        "REST",
+                        "schema=1 sub=rest comp=server operation=listen stat=error detail=" +
+                        SanitizeToken(ex.Message));
+                    Thread.Sleep(1000);
+                }
+                finally
+                {
+                    if (listener != null)
+                    {
+                        listener.Close();
+                    }
+                }
+            }
+        }
+
+        private static void HandleRestRequest(Socket client)
+        {
+            byte[] request = new byte[RestHeaderMaxLength + MqttCommandEnvelopeMaxLength];
+            int received = 0;
+            int bodyOffset = -1;
+            while (received < request.Length && bodyOffset < 0)
+            {
+                int count = client.Receive(request, received, request.Length - received, SocketFlags.None);
+                if (count <= 0)
+                {
+                    WriteRestResponse(client, 400, null);
+                    return;
+                }
+
+                received += count;
+                bodyOffset = FindRestBodyOffset(request, received);
+                if (bodyOffset > RestHeaderMaxLength)
+                {
+                    WriteRestResponse(client, 400, null);
+                    return;
+                }
+
+                if (bodyOffset < 0 && received >= RestHeaderMaxLength)
+                {
+                    WriteRestResponse(client, 400, null);
+                    return;
+                }
+            }
+
+            string headers = AsciiBytesToString(request, 0, bodyOffset);
+            int firstSpace = headers.IndexOf(' ');
+            int secondSpace = firstSpace < 0 ? -1 : headers.IndexOf(' ', firstSpace + 1);
+            if (firstSpace < 0 || secondSpace < 0)
+            {
+                WriteRestResponse(client, 400, null);
+                return;
+            }
+
+            string method = headers.Substring(0, firstSpace);
+            string path = headers.Substring(firstSpace + 1, secondSpace - firstSpace - 1);
+            if (path != RestCommandPath)
+            {
+                WriteRestResponse(client, 404, null);
+                return;
+            }
+
+            if (method != "POST")
+            {
+                WriteRestResponse(client, 405, null);
+                return;
+            }
+
+            int contentLength = ParseRestContentLength(headers);
+            if (contentLength <= 0 || contentLength > MqttCommandEnvelopeMaxLength)
+            {
+                WriteRestResponse(client, 400, null);
+                return;
+            }
+
+            int required = bodyOffset + contentLength;
+            while (received < required)
+            {
+                int count = client.Receive(request, received, required - received, SocketFlags.None);
+                if (count <= 0)
+                {
+                    WriteRestResponse(client, 400, null);
+                    return;
+                }
+
+                received += count;
+            }
+
+            string responseBody = ProcessApiCommand(AsciiBytesToString(request, bodyOffset, contentLength));
+            WriteRestResponse(client, 200, responseBody);
+        }
+
+        private static int FindRestBodyOffset(byte[] request, int length)
+        {
+            for (int index = 3; index < length; index++)
+            {
+                if (request[index - 3] == '\r' && request[index - 2] == '\n' &&
+                    request[index - 1] == '\r' && request[index] == '\n')
+                {
+                    return index + 1;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int ParseRestContentLength(string headers)
+        {
+            const string name = "\r\ncontent-length:";
+            string lower = headers.ToLower();
+            int start = lower.IndexOf(name);
+            if (start < 0)
+            {
+                return -1;
+            }
+
+            start += name.Length;
+            int end = lower.IndexOf("\r\n", start);
+            int value;
+            return end > start && TryParsePositiveInt(lower.Substring(start, end - start).Trim(), out value)
+                ? value
+                : -1;
+        }
+
+        private static void WriteRestResponse(Socket client, int statusCode, string body)
+        {
+            string reason = statusCode == 200 ? "OK" :
+                (statusCode == 404 ? "Not Found" :
+                (statusCode == 405 ? "Method Not Allowed" : "Bad Request"));
+            string payload = body == null ? string.Empty : body;
+            byte[] response = AsciiStringToBytes(
+                "HTTP/1.1 " + statusCode.ToString() + " " + reason + "\r\n" +
+                "Content-Type: application/json\r\n" +
+                "Content-Length: " + payload.Length.ToString() + "\r\n" +
+                "Connection: close\r\n\r\n" + payload);
+            int sent = 0;
+            while (sent < response.Length)
+            {
+                int count = client.Send(response, sent, response.Length - sent, SocketFlags.None);
+                if (count <= 0)
+                {
+                    return;
+                }
+
+                sent += count;
+            }
+        }
+
+        private static string AsciiBytesToString(byte[] bytes, int offset, int length)
+        {
+            char[] chars = new char[length];
+            for (int index = 0; index < length; index++)
+            {
+                byte value = bytes[offset + index];
+                chars[index] = value <= 0x7F ? (char)value : '?';
+            }
+
+            return new string(chars);
+        }
+    }
+}

--- a/software/nanoFramework/CubleyControl/Program.Commands.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.cs
@@ -27,18 +27,12 @@ namespace CubleyControl
             WriteStructuredDebug(
                 "COMMAND",
                 "schema=1 sub=command comp=dispatch operation=receive stat=ok" +
-                " transport=" + (_activeCommandTransport == CommandTransport.Mqtt ? "mqtt" : "cdc") +
+                " transport=" + (_activeCommandTransport == CommandTransport.Rest ? "rest" : "cdc") +
                 " command=" + SanitizeToken(_activeCommand));
 
             string[] tokens = SplitTokens(lower);
             string[] valueTokens = SplitTokens(normalized);
             _activeCommandIsSetter = IsSetterCommand(tokens);
-            if (_activeCommandTransport == CommandTransport.Mqtt && !IsMqttOperationalCommand(tokens))
-            {
-                WriteCommandResult(reqId, false, "unsupported", "command unavailable on mqtt", "transport=mqtt");
-                return;
-            }
-
             if (_activeCommandTransport == CommandTransport.Usb && _usbConfigurationMode)
             {
                 HandleConfigurationModeCommand(tokens, valueTokens, reqId);
@@ -237,7 +231,7 @@ namespace CubleyControl
 
             if (topic == "mqtt")
             {
-                WriteHumanHeading("MQTT commands");
+                WriteHumanHeading("MQTT state and configuration");
                 WriteHelpCommand("show mqtt", "Display live MQTT service state");
                 WriteHelpCommand("show running-config mqtt", "Display active MQTT configuration");
                 WriteHelpCommand("configure", "Change MQTT configuration");
@@ -303,7 +297,8 @@ namespace CubleyControl
             {
                 WriteHumanHeading("Capabilities");
                 WriteHumanField("Serial commands", "Available");
-                WriteHumanField("MQTT commands", "Available");
+                WriteHumanField("REST control", "Available");
+                WriteHumanField("MQTT state", "Available");
                 WriteHumanField("USB configuration", "Available");
                 WriteHumanField("MQTT configuration", "Unavailable");
                 return;
@@ -314,7 +309,7 @@ namespace CubleyControl
                 true,
                 "ok",
                 "capabilities",
-                "root=cubley/v1/diseqc serial_format=hybrid transport.serial=1 transport.mqtt=1 config_usb=1 config_mqtt=0");
+                "root=cubley/v2 serial_format=hybrid transport.serial=1 transport.rest=1 mqtt_state=1 config_usb=1 config_rest=0");
         }
 
         private static void EmitVersion(int reqId)
@@ -453,8 +448,8 @@ namespace CubleyControl
                 " operation=execute" +
                 " stat=" + (ok ? "ok" : "error") +
                 " code=" + code +
-                " transport=" + (_activeCommandTransport == CommandTransport.Mqtt ? "mqtt" : "cdc") +
-                (_activeCommandTransport == CommandTransport.Mqtt ? " id=" + SanitizeToken(_mqttActiveCommandKey) : string.Empty) +
+                " transport=" + (_activeCommandTransport == CommandTransport.Rest ? "rest" : "cdc") +
+                (_activeCommandTransport == CommandTransport.Rest ? " id=" + SanitizeToken(_mqttActiveCommandKey) : string.Empty) +
                 " request_id=" + reqId.ToString() +
                 " command=" + SanitizeToken(_activeCommand) +
                 " detail=" + safeMsg +
@@ -468,7 +463,7 @@ namespace CubleyControl
                 return;
             }
 
-            if (_activeCommandTransport == CommandTransport.Mqtt)
+            if (_activeCommandTransport == CommandTransport.Rest)
             {
                 RecordMqttCommandOutcome(ok, code, safeMsg);
                 return;

--- a/software/nanoFramework/CubleyControl/Program.Commands.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.cs
@@ -454,7 +454,7 @@ namespace CubleyControl
                 " stat=" + (ok ? "ok" : "error") +
                 " code=" + code +
                 " transport=" + (_activeCommandTransport == CommandTransport.Mqtt ? "mqtt" : "cdc") +
-                (_activeCommandTransport == CommandTransport.Mqtt ? " id=" + _mqttActiveCommandId.ToString() : string.Empty) +
+                (_activeCommandTransport == CommandTransport.Mqtt ? " id=" + SanitizeToken(_mqttActiveCommandKey) : string.Empty) +
                 " request_id=" + reqId.ToString() +
                 " command=" + SanitizeToken(_activeCommand) +
                 " detail=" + safeMsg +
@@ -468,9 +468,9 @@ namespace CubleyControl
                 return;
             }
 
-            if (ok && _activeCommandTransport == CommandTransport.Mqtt)
+            if (_activeCommandTransport == CommandTransport.Mqtt)
             {
-                _activeOutputSink("OK\r\n");
+                RecordMqttCommandOutcome(ok, code, safeMsg);
                 return;
             }
 

--- a/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
+++ b/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
@@ -46,7 +46,7 @@ namespace CubleyControl
         private static int _lnbFaultSequence;
         private static bool _lnbFaultCheckPending;
         private static readonly object _lnbFaultTransitionLock = new object();
-        // Shared command execution across transports (serial + MQTT). All
+        // Shared command execution across transports (serial + REST). All
         // commands funnel through ExecuteCommand -> HandleConsoleCommand ->
         // WriteCommandResult, which writes through whichever OutputSink is
         // active for the calling transport. The lock serializes command
@@ -57,7 +57,7 @@ namespace CubleyControl
         private enum CommandTransport
         {
             Usb,
-            Mqtt
+            Rest
         }
 
         private enum ConsoleTransport
@@ -95,7 +95,7 @@ namespace CubleyControl
         /// </summary>
         private static void ExecutePositionerOperation(int operation, int value, OutputSink outputSink)
         {
-            ExecuteCommandCore(CommandModePositioner, null, operation, value, outputSink, CommandTransport.Mqtt);
+            ExecuteCommandCore(CommandModePositioner, null, operation, value, outputSink, CommandTransport.Rest);
         }
 
         private static void ExecuteCommandCore(

--- a/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
+++ b/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
@@ -18,7 +18,6 @@ namespace CubleyControl
         private const int UsbConsoleHistoryDepth = 4;
         private const int ConsoleIdleTimeoutMs = 10 * 60 * 1000;
         private const int ConsoleIdleWarningMs = 60 * 1000;
-        private const int MqttCommandMaxLength = 64;
         private const int UsbWriteLogEveryNEvents = 20;
         private const int LnbFaultPollIntervalMs = 25;
         private const int LnbChannelA = 0;
@@ -81,7 +80,31 @@ namespace CubleyControl
             Debug.WriteLine("[" + subsystem + "] " + payload);
         }
 
+        private const int CommandModeConsoleText = 0;
+        private const int CommandModePositioner = 1;
+
         private static void ExecuteCommand(string command, OutputSink outputSink, CommandTransport transport)
+        {
+            ExecuteCommandCore(CommandModeConsoleText, command, 0, 0, outputSink, transport);
+        }
+
+        /// <summary>
+        /// Runs a positioner operation from already-typed parameters, taking
+        /// the same locks and hardware path as the console route without
+        /// building a command string to re-parse.
+        /// </summary>
+        private static void ExecutePositionerOperation(int operation, int value, OutputSink outputSink)
+        {
+            ExecuteCommandCore(CommandModePositioner, null, operation, value, outputSink, CommandTransport.Mqtt);
+        }
+
+        private static void ExecuteCommandCore(
+            int mode,
+            string command,
+            int operation,
+            int value,
+            OutputSink outputSink,
+            CommandTransport transport)
         {
             lock (_commandLock)
             {
@@ -92,7 +115,14 @@ namespace CubleyControl
                 {
                     lock (_lnbIoLock)
                     {
-                        HandleConsoleCommand(command);
+                        if (mode == CommandModeConsoleText)
+                        {
+                            HandleConsoleCommand(command);
+                        }
+                        else
+                        {
+                            RunPositionerOperation(operation, value);
+                        }
                     }
                 }
                 finally

--- a/software/nanoFramework/CubleyControl/Program.Jobs.cs
+++ b/software/nanoFramework/CubleyControl/Program.Jobs.cs
@@ -1,0 +1,319 @@
+using System;
+
+namespace CubleyControl
+{
+    public static partial class Program
+    {
+        // A positioner job is the only representation of "the dish is moving".
+        // It replaces the previous busy-flag-plus-deadline pair so that both
+        // transports, and any future client, can name and query a movement
+        // rather than only observing that something is in progress.
+        //
+        // There is deliberately no "succeeded" state: a DiSEqC 1.2 positioner
+        // reports no arrival indication, so the device only ever knows what it
+        // transmitted and how much time has elapsed. JobStateReleased records a
+        // client's assertion that motion finished, not a device observation.
+        private const int DiseqcJobHistoryDepth = 4;
+        private const string JobStateRunning = "running";
+        private const string JobStateHalted = "halted";
+        private const string JobStateTimeout = "timeout";
+        private const string JobStateTimeoutHaltFailed = "timeout_halt_failed";
+        private const string JobStateReleased = "released";
+
+        private static readonly object _diseqcJobLock = new object();
+        private static readonly int[] _diseqcJobIds = new int[DiseqcJobHistoryDepth];
+        private static readonly string[] _diseqcJobOps = new string[DiseqcJobHistoryDepth];
+        private static readonly string[] _diseqcJobStates = new string[DiseqcJobHistoryDepth];
+        private static readonly string[] _diseqcJobDetails = new string[DiseqcJobHistoryDepth];
+        private static readonly long[] _diseqcJobDeadlines = new long[DiseqcJobHistoryDepth];
+        private static readonly int[] _diseqcJobTimeouts = new int[DiseqcJobHistoryDepth];
+        private static int _diseqcJobRingNext;
+        private static int _diseqcNextJobId;
+        private static int _diseqcActiveJobId;
+        private static int _diseqcLastTerminalJobId;
+
+        // Per-command scratch used by the JSON response layer to report which
+        // job a command started, or which job refused it. Both are written
+        // only while _commandLock is held, like the other _active* command
+        // fields, and are reset at the start of every JSON command.
+        private static int _lastStartedDiseqcJobId;
+        private static int _blockingDiseqcJobId;
+
+        private static void ResetDiseqcJobCommandScratch()
+        {
+            _lastStartedDiseqcJobId = 0;
+            _blockingDiseqcJobId = 0;
+        }
+
+        private static int BeginDiseqcJob(string operation, int durationMs)
+        {
+            lock (_diseqcJobLock)
+            {
+                _diseqcNextJobId++;
+                if (_diseqcNextJobId <= 0)
+                {
+                    _diseqcNextJobId = 1;
+                }
+
+                int slot = _diseqcJobRingNext;
+                int timeoutMs = _diseqcMotionTimeoutMs;
+                _diseqcJobIds[slot] = _diseqcNextJobId;
+                _diseqcJobOps[slot] = operation;
+                _diseqcJobStates[slot] = JobStateRunning;
+                _diseqcJobDetails[slot] = string.Empty;
+                _diseqcJobTimeouts[slot] = timeoutMs;
+                _diseqcJobDeadlines[slot] = Environment.TickCount64 +
+                    (durationMs < timeoutMs ? durationMs : timeoutMs);
+                _diseqcJobRingNext = (slot + 1) % DiseqcJobHistoryDepth;
+                _diseqcActiveJobId = _diseqcNextJobId;
+                return _diseqcActiveJobId;
+            }
+        }
+
+        /// <summary>
+        /// Ends <paramref name="jobId"/> only if it is still the active job.
+        /// The identity check is what stops a late release or a stale watchdog
+        /// from terminating a newer movement.
+        /// </summary>
+        private static bool TryEndDiseqcJob(int jobId, string state, string detail)
+        {
+            lock (_diseqcJobLock)
+            {
+                if (jobId == 0 || _diseqcActiveJobId != jobId)
+                {
+                    return false;
+                }
+
+                int slot = FindDiseqcJobSlotLocked(jobId);
+                if (slot < 0)
+                {
+                    // Evicted from the ring while running, which can only
+                    // happen if history depth is exhausted; drop the active
+                    // marker so the positioner does not stay wedged busy.
+                    _diseqcActiveJobId = 0;
+                    return false;
+                }
+
+                _diseqcJobStates[slot] = state;
+                _diseqcJobDetails[slot] = detail == null ? string.Empty : detail;
+                _diseqcJobDeadlines[slot] = 0;
+                _diseqcActiveJobId = 0;
+                _diseqcLastTerminalJobId = jobId;
+                return true;
+            }
+        }
+
+        /// <summary>Ends whichever job is active. Returns its id, or 0 if none was.</summary>
+        private static int EndActiveDiseqcJob(string state, string detail)
+        {
+            int activeJobId;
+            lock (_diseqcJobLock)
+            {
+                activeJobId = _diseqcActiveJobId;
+            }
+
+            if (activeJobId == 0)
+            {
+                return 0;
+            }
+
+            return TryEndDiseqcJob(activeJobId, state, detail) ? activeJobId : 0;
+        }
+
+        private static int GetActiveDiseqcJobId()
+        {
+            lock (_diseqcJobLock)
+            {
+                return _diseqcActiveJobId;
+            }
+        }
+
+        /// <summary>Returns the active job id if its deadline has passed, else 0.</summary>
+        private static int GetExpiredDiseqcJobId()
+        {
+            lock (_diseqcJobLock)
+            {
+                if (_diseqcActiveJobId == 0)
+                {
+                    return 0;
+                }
+
+                int slot = FindDiseqcJobSlotLocked(_diseqcActiveJobId);
+                if (slot < 0 || Environment.TickCount64 < _diseqcJobDeadlines[slot])
+                {
+                    return 0;
+                }
+
+                return _diseqcActiveJobId;
+            }
+        }
+
+        private static bool TryGetDiseqcJobSnapshot(
+            int jobId,
+            out string operation,
+            out string state,
+            out int remainingMs,
+            out int timeoutMs,
+            out string detail)
+        {
+            operation = "idle";
+            state = string.Empty;
+            remainingMs = 0;
+            timeoutMs = 0;
+            detail = string.Empty;
+
+            lock (_diseqcJobLock)
+            {
+                int slot = FindDiseqcJobSlotLocked(jobId);
+                if (slot < 0)
+                {
+                    return false;
+                }
+
+                operation = _diseqcJobOps[slot];
+                state = _diseqcJobStates[slot];
+                timeoutMs = _diseqcJobTimeouts[slot];
+                detail = _diseqcJobDetails[slot];
+                remainingMs = state == JobStateRunning
+                    ? ClampRemainingMs(_diseqcJobDeadlines[slot] - Environment.TickCount64)
+                    : 0;
+                return true;
+            }
+        }
+
+        private static int FindDiseqcJobSlotLocked(int jobId)
+        {
+            if (jobId == 0)
+            {
+                return -1;
+            }
+
+            for (int slot = 0; slot < DiseqcJobHistoryDepth; slot++)
+            {
+                if (_diseqcJobIds[slot] == jobId)
+                {
+                    return slot;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int ClampRemainingMs(long remaining)
+        {
+            if (remaining <= 0)
+            {
+                return 0;
+            }
+
+            return remaining > int.MaxValue ? int.MaxValue : (int)remaining;
+        }
+
+        /// <summary>
+        /// Compatibility view for the console renderer and the schema-1 debug
+        /// log, both of which predate the job model and describe motion as a
+        /// busy flag plus a completion source.
+        /// </summary>
+        private static void GetDiseqcMotionSnapshot(
+            out bool busy,
+            out int motionId,
+            out string operation,
+            out int remainingMs,
+            out string completionSource)
+        {
+            int activeJobId = GetActiveDiseqcJobId();
+            int reportedJobId;
+            lock (_diseqcJobLock)
+            {
+                reportedJobId = activeJobId != 0 ? activeJobId : _diseqcLastTerminalJobId;
+            }
+
+            busy = activeJobId != 0;
+            motionId = reportedJobId;
+
+            string state;
+            int timeoutMs;
+            string detail;
+            if (!TryGetDiseqcJobSnapshot(reportedJobId, out operation, out state, out remainingMs, out timeoutMs, out detail))
+            {
+                operation = "idle";
+                remainingMs = 0;
+                completionSource = "none";
+                return;
+            }
+
+            if (busy)
+            {
+                completionSource = "pending";
+                return;
+            }
+
+            operation = "idle";
+            completionSource = state;
+        }
+
+        private static string BuildDiseqcJobJson(int jobId)
+        {
+            string operation;
+            string state;
+            int remainingMs;
+            int timeoutMs;
+            string detail;
+            if (!TryGetDiseqcJobSnapshot(jobId, out operation, out state, out remainingMs, out timeoutMs, out detail))
+            {
+                return "null";
+            }
+
+            return new JsonBuilder()
+                .AddInt("job", jobId)
+                .AddString("op", operation)
+                .AddString("state", state)
+                .AddInt("remaining_ms", remainingMs)
+                .AddInt("timeout_ms", timeoutMs)
+                .AddString("detail", detail)
+                .Build();
+        }
+
+        private static string BuildDiseqcStateJson()
+        {
+            int activeJobId = GetActiveDiseqcJobId();
+            int lastTerminalJobId;
+            lock (_diseqcJobLock)
+            {
+                lastTerminalJobId = _diseqcLastTerminalJobId;
+            }
+
+            return new JsonBuilder()
+                .AddInt("v", DeviceContractVersion)
+                .AddString("sub", "diseqc")
+                .AddString("comp", "state")
+                .AddBool("busy", activeJobId != 0)
+                .AddInt("timeout_ms", _diseqcMotionTimeoutMs)
+                .AddRaw("active", activeJobId == 0 ? "null" : BuildDiseqcJobJson(activeJobId))
+                .AddRaw("last", lastTerminalJobId == 0 ? "null" : BuildDiseqcJobJson(lastTerminalJobId))
+                .Build();
+        }
+
+        private static string BuildDiseqcJobEventJson(string transition, int jobId)
+        {
+            string operation;
+            string state;
+            int remainingMs;
+            int timeoutMs;
+            string detail;
+            TryGetDiseqcJobSnapshot(jobId, out operation, out state, out remainingMs, out timeoutMs, out detail);
+
+            return new JsonBuilder()
+                .AddInt("v", DeviceContractVersion)
+                .AddInt("event_id", NextMqttEventId())
+                .AddString("sub", "diseqc")
+                .AddString("comp", "job")
+                .AddString("transition", transition)
+                .AddInt("job", jobId)
+                .AddString("op", operation)
+                .AddString("state", state)
+                .AddInt("remaining_ms", remainingMs)
+                .Build();
+        }
+    }
+}

--- a/software/nanoFramework/CubleyControl/Program.cs
+++ b/software/nanoFramework/CubleyControl/Program.cs
@@ -29,6 +29,9 @@ namespace CubleyControl
             var mqttThread = new Thread(MqttLoop);
             mqttThread.Start();
 
+            var restThread = new Thread(RestLoop);
+            restThread.Start();
+
             var lnbHealthThread = new Thread(LnbHealthLoop);
             lnbHealthThread.Start();
 

--- a/software/nanoFramework/CubleyControl/packages.config
+++ b/software/nanoFramework/CubleyControl/packages.config
@@ -5,10 +5,10 @@
   <package id="nanoFramework.System.Device.Gpio" version="1.1.57" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Pwm" version="1.1.23" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.221" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.223" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hardware.Stm32" version="1.10.37" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.75" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.60" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.64" targetFramework="netnano1.0" />
 </packages>


### PR DESCRIPTION
## Summary
- add `POST /api/v2/commands` as the sole network control endpoint
- remove MQTT command subscriptions and response topics
- publish MQTT availability, events, and retained LNB/positioner state only
- preserve shared USB/REST hardware command paths and positioner job tracking
- update API documentation and align nanoFramework network dependencies

## Validation
- `./toolchain/build-CubleyControl.sh build --project CubleyControl/CubleyControl.nfproj --configuration Debug`
- deterministic bundle: 233,260 bytes, 28,884 bytes free in the 256 KiB managed region
- `git diff --check`
- verified no MQTT receive handlers, subscriptions, or command/response topic construction remain

## Hardware
- not deployed or exercised on target hardware
