### PR TITLE
chore(devcontainer): pin nanoff and remove ssh mount

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,6 +90,7 @@ RUN apt-get install -y --no-install-recommends \
     xxd \
     jq \
     rsync \
+    fd-find \
     # poppler-utils (pdftotext)
     poppler-utils
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -140,9 +140,11 @@ RUN ln -sf /usr/bin/dotnet /usr/local/bin/msbuild \
     && ln -sf /usr/bin/dotnet /usr/local/bin/xbuild
 
 # ---- Install nanoFramework tools ----
+ARG NANOFF_VERSION=2.5.162
 RUN mkdir -p /usr/local/share/dotnet-tools \
-    && dotnet tool install --tool-path /usr/local/share/dotnet-tools nanoff \
-    && ln -sf /usr/local/share/dotnet-tools/nanoff /usr/local/bin/nanoff
+    && dotnet tool install --tool-path /usr/local/share/dotnet-tools nanoff --version ${NANOFF_VERSION} \
+    && ln -sf /usr/local/share/dotnet-tools/nanoff /usr/local/bin/nanoff \
+    && nanoff --version
 
 # ---- hex2dfu ----
 ENV HEX2DFU_PATH=/usr/local/bin/hex2dfu

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,9 +14,6 @@
 		//OPTIONAL: Mount gh cli config for seamless GitHub auth and access to private repos
 		"source=${env:HOME}${env:USERPROFILE}/.config/gh,target=/home/vscode/.config/gh,type=bind",
 
-		// OPTIONAL: Mount ssh agent socket for seamless ssh auth to git repos and other servers
-		"source=${env:HOME}${env:USERPROFILE}/.ssh/agent.sock,target=/tmp/ssh-agent.sock,type=bind",
-
 		// OPTIONAL: Mount .azure folder for seamless az cli auth
 		// "source=${env:HOME}${env:USERPROFILE}/.azure,target=/home/vscode/.azure,type=bind"
 		// OPTIONAL: Mount workspace-specific agent skills


### PR DESCRIPTION
## Summary
- install `fd-find` in the devcontainer
- pin `nanoff` to version `2.5.162` for reproducible devcontainer builds
- verify the installed `nanoff` version during image construction
- remove the host-specific SSH agent socket mount

## Validation
- `git diff --check -- .devcontainer`
- confirmed `fd-find` is available from Debian trixie package metadata
- parsed `.devcontainer/devcontainer.json` successfully as JSONC