### PR TITLE
Harden CubleyControl deployment bundle packing

### DIFF
--- a/software/nanoFramework/toolchain/CubleyControl-deployment-config-test.py
+++ b/software/nanoFramework/toolchain/CubleyControl-deployment-config-test.py
@@ -33,7 +33,7 @@ EXPECTED_BUILD_MANIFEST = [
     "$OUTPUT_DIR/nanoFramework.Runtime.Native.pe",
     "$OUTPUT_DIR/nanoFramework.System.Collections.pe",
     "$OUTPUT_DIR/System.IO.Streams.pe",
-    "$OUTPUT_DIR/nanoFramework.System.Text.pe",
+    "$SYSTEM_TEXT_PE",
     "$OUTPUT_DIR/System.Net.pe",
     "$OUTPUT_DIR/nanoFramework.M2Mqtt.Core.pe",
     "$OUTPUT_DIR/nanoFramework.M2Mqtt.pe",
@@ -103,6 +103,30 @@ require(
 require(
     'Required deployment assembly missing:' in build_script,
     "build script does not fail closed for a missing required assembly",
+)
+require(
+    'system_text_candidates=("$ROOT_DIR"/packages/nanoFramework.System.Text.*/lib/nanoFramework.System.Text.pe)' in build_script,
+    "build script does not resolve the transitive System.Text deployment assembly",
+)
+require(
+    'Required deployment packer is unavailable:' in build_script,
+    "build script does not fail closed when the deployment packer is unavailable",
+)
+require(
+    'packed_bundle="$(readlink -f "$latest_bundle")"' in build_script and
+    'python3 "$SCRIPT_DIR/inspect_deploy_bundle.py" "$packed_bundle"' in build_script,
+    "build script does not resolve and validate the authoritative packed bundle",
+)
+require(
+    'output_tmp="$(mktemp "$OUTPUT_DIR/.${TARGET_NAME}.bin.XXXXXX")"' in build_script and
+    'cp "$packed_bundle" "$output_tmp"' in build_script and
+    'mv -f "$output_tmp" "$OUTPUT_BIN"' in build_script and
+    'cmp -s "$packed_bundle" "$OUTPUT_BIN"' in build_script,
+    "build script does not atomically publish and compare the compatibility bundle",
+)
+require(
+    'bundle_name="${TARGET_NAME}_bundle_${timestamp}.bin"' not in build_script,
+    "build script still republishes the validated bundle through a second timestamped copy",
 )
 
 deploy_script = deploy_script_path.read_text(encoding="utf-8")

--- a/software/nanoFramework/toolchain/build-CubleyControl.sh
+++ b/software/nanoFramework/toolchain/build-CubleyControl.sh
@@ -614,6 +614,7 @@ else
   CUBLEY_INTEROP_PE="$OUTPUT_DIR/CubleyNative.pe"
   CUBLEY_DISEQC_MANAGED_PE="$OUTPUT_DIR/CubleyDiseqcManaged.pe"
   RUNTIME_EVENTS_PE=""
+  SYSTEM_TEXT_PE=""
 
   if [[ "$SKIP_INTEROP_VALIDATION" != "true" && -x "$CHECKSUM_TOOL" ]]; then
     if [[ -f "$CUBLEY_INTEROP_PE" ]]; then
@@ -636,6 +637,17 @@ else
     fi
   fi
 
+  if [[ -f "$OUTPUT_DIR/nanoFramework.System.Text.pe" ]]; then
+    SYSTEM_TEXT_PE="$OUTPUT_DIR/nanoFramework.System.Text.pe"
+  else
+    shopt -s nullglob
+    system_text_candidates=("$ROOT_DIR"/packages/nanoFramework.System.Text.*/lib/nanoFramework.System.Text.pe)
+    shopt -u nullglob
+    if [[ ${#system_text_candidates[@]} -gt 0 ]]; then
+      SYSTEM_TEXT_PE="$(printf '%s\n' "${system_text_candidates[@]}" | sort -V | tail -n1)"
+    fi
+  fi
+
   if [[ -f "$PRIMARY_PE" ]]; then
     required_pe_paths=(
       "$PRIMARY_PE"
@@ -648,7 +660,7 @@ else
       "$OUTPUT_DIR/nanoFramework.Runtime.Native.pe"
       "$OUTPUT_DIR/nanoFramework.System.Collections.pe"
       "$OUTPUT_DIR/System.IO.Streams.pe"
-      "$OUTPUT_DIR/nanoFramework.System.Text.pe"
+      "$SYSTEM_TEXT_PE"
       "$OUTPUT_DIR/System.Net.pe"
       "$OUTPUT_DIR/nanoFramework.M2Mqtt.Core.pe"
       "$OUTPUT_DIR/nanoFramework.M2Mqtt.pe"
@@ -658,7 +670,7 @@ else
     missing_required_pe="false"
     for required_pe in "${required_pe_paths[@]}"; do
       if [[ -z "$required_pe" || ! -f "$required_pe" ]]; then
-        echo "[error] Required deployment assembly missing: ${required_pe:-nanoFramework.Runtime.Events.pe}" >&2
+        echo "[error] Required deployment assembly missing: ${required_pe:-resolved package assembly}" >&2
         missing_required_pe="true"
       fi
     done
@@ -673,24 +685,37 @@ else
       "${required_pe_paths[@]}"
     )
 
-    if [[ -x "$SCRIPT_DIR/pack-and-validate.sh" ]]; then
-      "$SCRIPT_DIR/pack-and-validate.sh" "${pack_args[@]}" >/dev/null
+    if [[ ! -x "$SCRIPT_DIR/pack-and-validate.sh" ]]; then
+      echo "[error] Required deployment packer is unavailable: $SCRIPT_DIR/pack-and-validate.sh" >&2
+      exit 1
     fi
 
-    if [[ -L "$OUTPUT_DIR/latest.deploy.bin" || -f "$OUTPUT_DIR/latest.deploy.bin" ]]; then
-      cp -f "$OUTPUT_DIR/latest.deploy.bin" "$OUTPUT_BIN"
-      echo "Created deterministic deployment bundle: $OUTPUT_BIN"
+    "$SCRIPT_DIR/pack-and-validate.sh" "${pack_args[@]}"
+
+    latest_bundle="$OUTPUT_DIR/latest.deploy.bin"
+    packed_bundle="$(readlink -f "$latest_bundle")"
+    if [[ -z "$packed_bundle" || ! -f "$packed_bundle" ]]; then
+      echo "[error] Deployment packer did not publish a valid latest bundle: $latest_bundle" >&2
+      exit 1
     fi
 
-    if [[ -f "$OUTPUT_BIN" ]]; then
-      timestamp="$(date +%Y%m%d-%H%M%S)"
-      bundle_name="${TARGET_NAME}_bundle_${timestamp}.bin"
-      bundle_path="$OUTPUT_DIR/$bundle_name"
-      cp "$OUTPUT_BIN" "$bundle_path"
-      ln -sf "$bundle_name" "$OUTPUT_DIR/latest.deploy.bin"
-      echo "Created timestamped bundle: $bundle_path"
-      echo "Updated symlink: $OUTPUT_DIR/latest.deploy.bin -> $bundle_name"
+    python3 "$SCRIPT_DIR/inspect_deploy_bundle.py" "$packed_bundle"
+
+    output_tmp="$(mktemp "$OUTPUT_DIR/.${TARGET_NAME}.bin.XXXXXX")"
+    trap 'rm -f "$output_tmp"; cleanup' EXIT
+    cp "$packed_bundle" "$output_tmp"
+    python3 "$SCRIPT_DIR/inspect_deploy_bundle.py" "$output_tmp"
+    mv -f "$output_tmp" "$OUTPUT_BIN"
+    trap cleanup EXIT
+
+    if ! cmp -s "$packed_bundle" "$OUTPUT_BIN"; then
+      echo "[error] Compatibility deployment image differs from validated bundle: $OUTPUT_BIN" >&2
+      exit 1
     fi
+
+    echo "Created deterministic deployment bundle: $OUTPUT_BIN"
+    echo "Validated deployment bundle: $packed_bundle"
+    echo "Updated symlink: $latest_bundle -> $(readlink "$latest_bundle")"
   fi
 fi
 

--- a/software/nanoFramework/toolchain/pack-and-validate.sh
+++ b/software/nanoFramework/toolchain/pack-and-validate.sh
@@ -102,6 +102,7 @@ esac
 
 mkdir -p "$OUT_DIR"
 
+EXPECTED_SIZE=0
 for f in "${ARGS[@]}"; do
   if [[ ! -f "$f" ]]; then
     fail "input not found: $f"
@@ -119,6 +120,9 @@ for f in "${ARGS[@]}"; do
   if [[ "$REQUIRED_MARKER" != "ANY" && "$marker_name" != "$REQUIRED_MARKER" ]]; then
     fail "marker policy violation: $f has $marker_name, required $REQUIRED_MARKER"
   fi
+
+  input_size="$(stat -c '%s' "$f")"
+  EXPECTED_SIZE=$((EXPECTED_SIZE + input_size))
 done
 
 if [[ -z "$OUT_BASE" ]]; then
@@ -133,6 +137,11 @@ LATEST_LINK="$OUT_DIR/latest.deploy.bin"
 cat "${ARGS[@]}" > "$OUT_FILE"
 
 OUT_SIZE="$(stat -c '%s' "$OUT_FILE")"
+if (( OUT_SIZE != EXPECTED_SIZE )); then
+  rm -f "$OUT_FILE"
+  fail "output size mismatch: ${OUT_SIZE} bytes written, expected ${EXPECTED_SIZE} bytes"
+fi
+
 if (( OUT_SIZE > DEPLOY_REGION_MAX_BYTES )); then
   rm -f "$OUT_FILE"
   fail "output too large: ${OUT_SIZE} bytes > ${DEPLOY_REGION_MAX_BYTES} bytes (deployment region limit)"
@@ -144,5 +153,6 @@ ln -sfn "$(basename "$OUT_FILE")" "$LATEST_LINK"
 
 echo "PACK_OK: $OUT_FILE"
 echo "SIZE_OK: $OUT_SIZE bytes"
+echo "INPUT_COUNT: ${#ARGS[@]}"
 echo "MARKER_POLICY: $REQUIRED_MARKER"
 echo "LATEST: $LATEST_LINK -> $(readlink "$LATEST_LINK")"


### PR DESCRIPTION
## Summary

- Packing is mandatory and fail-closed.
- Output size equals the sum of inputs.
- The authoritative packer artifact and compatibility image are validated and byte-compared.
- Compatibility publication is atomic and concurrency-safe.
- The transitive nanoFramework.System.Text PE is resolved from the package cache when absent from build output.
- Redundant second timestamped republish is removed.

## Validation

- Shell syntax PASS
- CubleyControl-deployment-config-test.py PASS
- git diff --check PASS
- Full Debug build PASS
- Bundle 226,712 bytes with 15 NFMRK1 records
- No deployment performed.