### PR TITLE
Fix canonical DiSEqC GoToX angle encoding

### DIFF
--- a/docs/debug/GOTO_ANGLE_ASTRA2F_TEST_PLAN_2026-09-02.md
+++ b/docs/debug/GOTO_ANGLE_ASTRA2F_TEST_PLAN_2026-09-02.md
@@ -1,0 +1,252 @@
+# GoTo-Angle Astra 2F Repeatability Test Plan
+
+Date: 2026-09-02
+DUT: Cubley `cubley-a02663` with TM-2300 M3 positioner
+Target: Astra 2F / 28.2 degrees east orbital slot
+
+## Purpose
+
+Prove that `diseqc goto-angle` can return the dish to the same 28.2 degrees east
+RF peak after approaching from both lower and higher motor angles. This is a
+bounded Gate 0 test, not an autonomous scan and not proof of motor feedback.
+
+The test uses a stable horizontal, low-band anchor near 11.224 GHz RF
+(approximately 1.474 GHz IF with a 9.75 GHz LO). Confirm the carrier assignment
+before the run. Without independently verified service or catalogue metadata,
+the RF result proves pointing at the 28.2 degrees east Astra cluster rather than
+identifying the transmitting spacecraft uniquely as Astra 2F.
+
+## Safety Gates
+
+1. Confirm the motor's physical east/west stops, clear travel path, cable slack,
+   dish fasteners, and mechanical zero/reference before applying movement.
+2. Keep an immediately available `diseqc stop` command throughout the test.
+3. Use conservative volatile software limits strictly inside the physical stops.
+   Limits start disabled after every Cubley boot and must never be copied from
+   this document without checking the installation.
+4. Test only the target and two nearby flank positions. Do not use continuous
+   drive or raw `diseqc tx`.
+5. Stop on an unexpected direction, LNB fault, obstruction, cable tension,
+   watchdog expiry, MQTT/console loss, or uncertain motion state.
+6. User commands are issued over USB CDC. That console is not accessible from
+   the development container.
+
+## Values Required Before Arming Motion
+
+Record these values before sending `diseqc angle-limits`:
+
+| Item | Value |
+| --- | --- |
+| Station latitude, north positive | |
+| Station longitude, east positive | |
+| Independently calculated target direction | |
+| Independently calculated target magnitude | |
+| Cubley target after tenth-degree GoToX quantization (`A`) | |
+| Lower signed-motor-angle flank (`L`) | |
+| Higher signed-motor-angle flank (`H`) | |
+| Command-coordinate mapping to observed physical east/west movement | |
+| East software limit | |
+| West software limit | |
+| Motion watchdog | |
+| RF receiver path and configuration | |
+| Anchor centre frequency | |
+
+Calculate the initial target using the host helper, substituting the measured
+station coordinates:
+
+```bash
+cd /workspaces/diseqc_cntrl
+PYTHONPATH=software/transponder-mapper/src /usr/bin/python3 -c \
+  'from satmap.central.usals import calculate_motor_target; print(calculate_motor_target(LATITUDE, LONGITUDE, 28.2))'
+```
+
+Cross-check the result against one independent USALS implementation or a
+known-good receiver before motion. Use a signed motor coordinate only in the
+worksheet: east is positive and west is negative. Convert each command to
+Cubley's explicit direction plus unsigned magnitude. In this plan, increasing
+and decreasing refer only to that signed command coordinate. Record the observed
+physical dish direction separately during the first screening legs; do not infer
+it from the words `L`, `H`, east, or west.
+
+Start with flank positions one motor degree on either side of `A`:
+
+$$L=A-1.0^\circ$$
+
+$$H=A+1.0^\circ$$
+
+Both flanks must remain inside the verified software and hardware limits. A
+one-degree offset should produce a clear anchor reduction for a typical Ku dish.
+If it does not, increase the offset only after stopping and reassessing clearance;
+do not exceed two degrees during this Gate 0 test.
+
+## Measurement Metric
+
+Use one receiver path and unchanged gain, bandwidth, detector, averaging, and
+LNB state for the entire run. Prefer the rooftop bladeRF/Cubley path; the indoor
+Siglent may provide a separate corroborating series.
+
+For each dwell, record integrated anchor power relative to adjacent noise:
+
+$$C/N_{adj}=P_{carrier}-P_{adjacent\ noise}$$
+
+This relative metric is less sensitive than raw power to slow gain drift. Do not
+change SDR gain or analyser reference settings after collecting the baseline.
+
+## Preflight
+
+1. Start an MQTT event/state capture if available, while retaining USB CDC for
+   the interactive safety command.
+2. Set and verify the anchor LNB state:
+
+   ```text
+   lnb a enable
+   lnb a polarization horizontal
+   lnb a band low
+   show lnb a
+   ```
+
+3. Tune the receiver to the anchor and allow the LNB/receiver to warm and settle.
+4. With the dish already peaked at the known anchor, collect ten stationary
+   $C/N_{adj}$ measurements at fixed intervals. Record mean $\mu_0$ and standard
+   deviation $\sigma_0$. Define the measurable-change threshold
+   $T=\max(1.0\ \mathrm{dB},3\sigma_0)$ before moving.
+5. Confirm fail-closed behavior after boot: `diseqc angle-limits status` must show
+   disabled until deliberately armed. Do not issue a movement merely to test
+   rejection if the current physical position is uncertain.
+6. Configure checked limits and a watchdog no longer than 30 seconds for these
+   one-to-two-degree legs, then read them back. Reduce it further only if prior
+   measured travel time provides adequate margin; do not use the 90-second
+   default for this bounded test.
+
+   ```text
+   diseqc angle-limits <east_limit_deg> <west_limit_deg>
+   diseqc timeout <seconds>
+   diseqc angle-limits status
+   diseqc timeout status
+   show diseqc
+   ```
+
+7. Verify the reported LNB voltage is appropriate for horizontal polarization
+   and record it. The movement voltage affects travel time, not destination.
+
+## Motion Handling For Every Leg
+
+1. Send one `diseqc goto-angle <east|west> <degrees>` command and record its
+   motion ID, requested angle, encoded angle, direction, and movement voltage.
+2. Confirm the initial physical movement is in the expected direction. Send
+   `diseqc stop` immediately if it is not.
+3. Wait until the motor has physically stopped, then allow a fixed mechanical
+   settle interval of at least five seconds.
+4. Send `diseqc complete <motion_id>` only after observing the physical stop.
+   This command sends no Halt; it only releases the matching firmware motion
+   lock and records `completion=external`, `position_confidence=estimated`. This
+   is an open-loop estimate at the encoded target, not stop sensing or RF
+   verification. If
+   physical cessation is uncertain, use `diseqc stop` instead and abort the run.
+5. Run `show diseqc` and confirm the lock is idle, completion is `external`, and
+   the requested/encoded target matches the worksheet.
+6. Reapply the LNB state, then verify it before measuring RF:
+
+   ```text
+   lnb a polarization horizontal
+   lnb a band low
+   show lnb a
+   show diseqc
+   ```
+
+7. Reject the dwell if completion is `timeout`, confidence is
+   `verification_failed`, the encoded target differs from the worksheet, or an
+   LNB/motion fault occurred.
+
+If the watchdog expires, firmware attempts Halt, clears the motion lock, and
+sets `position_confidence=verification_failed`. Do not send another movement.
+Confirm physical cessation, issue `diseqc stop` if any doubt remains, inspect
+`show diseqc` and `show lnb a`, disable angular limits, and end the test. If Halt
+fails or motion continues, disable LNB/motor power using the station's emergency
+power procedure.
+
+## Test Sequence
+
+Run one screening cycle first:
+
+1. `A -> L`: confirm the physical direction matches the recorded mapping and the
+   anchor decreases by at least $T$.
+2. `L -> A`: settle, reapply LNB state, and measure the anchor.
+3. `A -> H`: confirm the physical direction reverses and the anchor decreases by
+   at least $T$.
+4. `H -> A`: settle, reapply LNB state, and measure the anchor.
+
+Stop here if either return fails. If both returns pass, run two more cycles for
+three arrivals at `A` from each direction. Alternate the order to limit drift:
+
+```text
+Cycle 1: A -> L -> A -> H -> A
+Cycle 2: A -> H -> A -> L -> A
+Cycle 3: A -> L -> A -> H -> A
+```
+
+Do not count the initial already-peaked baseline as a directional arrival.
+
+## Results
+
+| Cycle | Approach to A | Motion ID | Requested A | Encoded A | Completion | Settle (s) | $C/N_{adj}$ (dB) | Result/notes |
+| ---: | --- | ---: | ---: | ---: | --- | ---: | ---: | --- |
+| 1 | from L / increasing angle | | | | | | | |
+| 1 | from H / decreasing angle | | | | | | | |
+| 2 | from H / decreasing angle | | | | | | | |
+| 2 | from L / increasing angle | | | | | | | |
+| 3 | from L / increasing angle | | | | | | | |
+| 3 | from H / decreasing angle | | | | | | | |
+
+Record separately:
+
+| Metric | Result |
+| --- | ---: |
+| Baseline mean $\mu_0$ | |
+| Baseline standard deviation $\sigma_0$ | |
+| Measurable-change threshold $T$ | |
+| Mean after increasing-angle approach | |
+| Mean after decreasing-angle approach | |
+| Difference between directional means | |
+| Worst return below baseline mean | |
+| Unexpected direction/fault/watchdog count | |
+
+## Pass Criteria
+
+All conditions must pass:
+
+1. Six of six directional arrivals reacquire the same anchor carrier.
+2. Every arrival encodes exactly the same target `A`; no arrival completes by
+   watchdog timeout or reports `verification_failed`.
+3. Every returned $C/N_{adj}$ is no more than $T$ below the stationary baseline
+   mean.
+4. The two directional mean values differ by no more than
+   $T$.
+5. Both flanks are at least $T$ below the stationary target baseline, proving
+   that the sequence crossed the local RF peak rather than remaining inside a
+   flat measurement region.
+6. There are no unexpected-direction events, LNB faults, motion faults,
+   obstructions, cable concerns, or emergency stops.
+
+If only the directional-mean criterion fails, record the result as backlash or
+approach-direction dependence, not as a reliable pass. Retain separate preferred
+angles by approach direction until a later lobe fit determines a compensation.
+
+## Shutdown
+
+1. Return to `A` only if the last movement state is known and the test remains
+   inside all safety gates; otherwise send `diseqc stop` and leave position
+   confidence unknown.
+2. Disable angular movement for the remainder of the session:
+
+   ```text
+   diseqc angle-limits off
+   diseqc angle-limits status
+   show diseqc
+   ```
+
+3. Apply the station's normal LNB power policy.
+4. Preserve receiver traces, command/event capture, calculated target, firmware
+   build identity, and this completed worksheet.
+5. Append one factual PASS or FAIL entry to `docs/debug/BRINGUP_TEST_LOG.md` after
+   reviewing the artifacts. Do not log a timeout as successful arrival.

--- a/docs/software/INTERFACE_COMMAND_MAP_V1.md
+++ b/docs/software/INTERFACE_COMMAND_MAP_V1.md
@@ -532,6 +532,9 @@ Raw `diseqc tx` frames are transmitted unchanged. Successful `goto`, `goto-angle
 raw frames. Step commands use a step-derived deadline capped by the configured
 motion watchdog timeout; goto and drive use the configured motion watchdog timeout directly. The timeout defaults to
 90 seconds and is adjustable from 5 to 300 seconds with `diseqc timeout <seconds>`.
+First-class motor movement temporarily selects horizontal polarization so the
+positioner receives 18 V for the full motion. The previous polarization is
+restored when the motion is completed, halted, or timed out.
 When the timeout elapses, the firmware transmits Halt automatically and marks the
 motion complete with `completion=timeout`. `diseqc stop` is always accepted and
 clears the lock after transmitting Halt. An external completion command must

--- a/docs/software/INTERFACE_COMMAND_MAP_V1.md
+++ b/docs/software/INTERFACE_COMMAND_MAP_V1.md
@@ -116,8 +116,26 @@ CubleyControl console
 |   |         Set the switch current limit.
 |   |
 |   |-- diseqc
-|   |   |-- goto <0..255>
-|   |   |     Move to a stored position.
+|   |   |-- goto <0..60>
+|   |   |     Move to a TM-2300 stored position; position 0 is the reference.
+|   |   |-- goto-angle <east|west> <0..180 degrees>
+|   |   |     Move to a GoToX angular position within configured software limits.
+|   |   |-- reference
+|   |   |     Move to motor reference position 0.
+|   |   |-- store <1..60>
+|   |   |     Store the current physical position in the motor.
+|   |   |-- recalculate
+|   |   |     Send the motor's basic re-synchronize/position-shift command.
+|   |   |-- motor-limit <east|west|off>
+|   |   |     Set or disable the motor's internal limits at the current position.
+|   |   |-- angle-limits status|off
+|   |   |     Inspect or disable the volatile angular software limits.
+|   |   |-- angle-limits <east_degrees> <west_degrees>
+|   |   |     Arm direction-specific software limits after checking hardware stops.
+|   |   |-- step-calibration status|off
+|   |   |     Inspect or disable volatile open-loop step calibration.
+|   |   |-- step-calibration <east_deg_per_step> <west_deg_per_step>
+|   |   |     Set direction-specific step sizes with up to six decimal places.
 |   |   |-- step <east|west> <1..128>
 |   |   |     Move a fixed number of steps.
 |   |   |-- drive <east|west>
@@ -480,7 +498,18 @@ mutations are accepted only after entering configuration mode.
 
 | Command | Accepted values and behavior |
 |---|---|
-| `diseqc goto <position>` | Go to stored position `0..255`. This is not an angle command. |
+| `diseqc goto <position>` | Go to TM-2300 stored position `0..60`. Position `0` is the motor reference; this is not an angle command. |
+| `diseqc goto-angle <east\|west> <degrees>` | Send positioner command `0x6E` for an explicit motor angle. Decimal degrees are rounded to the nearest tenth, with half-step ties rounded upward, then encoded with the DiSEqC GoToX fractional lookup. A direction-specific software limit must first be configured. |
+| `diseqc reference` | Send `0x6B 0x00` to move to the motor's reference position. |
+| `diseqc store <position>` | Store the current physical position in motor slot `1..60` with command `0x6A`. |
+| `diseqc recalculate` | Send the basic `0x6F 0x00` Set/Recalculate Positions command. For the TM-2300 receiver workflow this re-synchronizes the selected stored position and shifts the others; the DiSEqC specification defines parameter `0x00` as manufacturer-specific, so verify this behavior on the installed motor before relying on it. |
+| `diseqc motor-limit <east\|west\|off>` | Send motor-internal limit command `0x66`, `0x67`, or `0x63`. East or west records the motor's current physical position as that limit. This does not configure Cubley's angular safety limits. |
+| `diseqc angle-limits <east_degrees> <west_degrees>` | Set positive, direction-specific runtime limits in the protocol range through 180 degrees. Rejected during motion. The operator must choose values strictly inside the motor's physically adjusted hardware stops. |
+| `diseqc angle-limits status` | Show whether angular motion is armed and both direction limits. |
+| `diseqc angle-limits off` | Disable angular movement. This is the power-on default and is rejected during motion. |
+| `diseqc step-calibration <east_deg_per_step> <west_deg_per_step>` | Set volatile direction-specific step sizes with up to six decimal places. Calibration starts disabled after boot. |
+| `diseqc step-calibration status` | Show step calibration and position-estimate state. |
+| `diseqc step-calibration off` | Disable step calibration. |
 | `diseqc step <east\|west> <steps>` | Move `1..128` steps. |
 | `diseqc drive <east\|west>` | Start continuous movement. |
 | `diseqc stop` | Transmit the positioner halt command. |
@@ -495,16 +524,47 @@ mutations are accepted only after entering configuration mode.
 | `diseqc tone status` | Show carrier state and settings. |
 | `diseqc listen <on\|off>` | Enable or disable the channel-A LNBH26 external DiSEqC input; boolean aliases are accepted. |
 
-The selected preset prefixes `goto`, `step`, `drive`, and `stop`. Raw `diseqc tx`
-frames are transmitted unchanged. Successful `goto`, `step`, and `drive` commands
-hold a motion lock that rejects further movement and raw frames. Step commands use
-a step-derived deadline capped by the configured motion watchdog timeout; goto and
-drive use the configured motion watchdog timeout directly. The timeout defaults to
+The selected preset prefixes all first-class positioner commands, including
+`goto`, `goto-angle`, `reference`, `store`, `recalculate`, `motor-limit`, `step`,
+`drive`, and `stop`.
+Raw `diseqc tx` frames are transmitted unchanged. Successful `goto`, `goto-angle`,
+`step`, and `drive` commands hold a motion lock that rejects further movement and
+raw frames. Step commands use a step-derived deadline capped by the configured
+motion watchdog timeout; goto and drive use the configured motion watchdog timeout directly. The timeout defaults to
 90 seconds and is adjustable from 5 to 300 seconds with `diseqc timeout <seconds>`.
 When the timeout elapses, the firmware transmits Halt automatically and marks the
 motion complete with `completion=timeout`. `diseqc stop` is always accepted and
 clears the lock after transmitting Halt. An external completion command must
 include the current motion ID so a delayed signal cannot release a newer movement.
+
+`goto-angle` uses the DiSEqC 1.2 five-byte form `E0 31 6E xx xx`.
+The two data bytes contain an east (`0xE`) or west (`0xD`) direction nibble and
+a whole-degree magnitude followed by the standard fractional-tenth code lookup
+`0,2,3,5,6,8,A,B,D,E`. For example, east `36.6` encodes as `E2 4A`.
+Input is strict unsigned decimal text with at most six fractional digits; signs,
+exponent notation, and locale decimal separators are rejected because direction
+is a separate argument. The local estimate remains in microdegrees so calibrated
+steps can retain finer resolution than the GoToX command.
+
+Angular software limits are deliberately volatile and start disabled after every
+boot. This fail-closed behavior requires the operator or future station
+orchestrator to confirm the motor's adjustable hardware stops before arming a
+bounded session. A configured software value is not evidence that the physical
+hardware limit was measured correctly.
+
+Motion command results and DiSEqC state/events record `command_mode`,
+`requested_angle_deg`, `encoded_angle_deg`, `direction`, `movement_voltage_v`,
+`position_confidence`, `estimated_angle_deg`, `position_source`,
+`pending_target_deg`, `step_calibration_configured`, `east_step_deg`, and
+`west_step_deg`. The retained state also records
+`angle_limits_configured`, `east_limit_deg`, and `west_limit_deg`. A successful
+GoToX transmission records a pending target without changing the previous
+estimate. Matching external completion adopts the encoded target as
+`position_confidence=estimated`. A calibrated step similarly adopts its pending
+target on external completion. Stored-position movement, reference movement,
+continuous drive, Halt, uncalibrated step completion, and raw positioner commands
+leave the angular estimate `unknown`; watchdog expiry sets `verification_failed`.
+No command-only transition is reported as `rf_verified`.
 
 ## Canonical Command IDs
 

--- a/docs/software/MQTT_API.md
+++ b/docs/software/MQTT_API.md
@@ -1,9 +1,5 @@
 # MQTT API Reference
 
-MQTT is an outbound-only state announcement interface. CubleyControl does not
-subscribe to command topics and MQTT cannot initiate hardware operations. REST
-control is defined in [DEVICE_API_V2.md](DEVICE_API_V2.md).
-
 The target structured payload and subsystem ownership rules are defined in
 [OBSERVABILITY_CONTRACT_V1.md](OBSERVABILITY_CONTRACT_V1.md). This document
 describes the currently implemented MQTT transport; topic migration is tracked in
@@ -15,29 +11,66 @@ CubleyControl uses MQTT 3.1.1 without TLS. It connects through the STM32F407
 Ethernet MAC and LAN8742A PHY after IPv4 and DNS are ready.
 
 The configured topic prefix is `diseqc` by default. The effective device root is
-`<prefix>/<hostname>`.
+`<prefix>/<hostname>`. MQTT carries one complete operational command line rather
+than using a separate topic for every operation. It shares the operational parser
+with USB CDC but has a strict allowlist and does not expose administrative
+configuration commands.
 
 | Direction | Topic | Payload | QoS | Retained |
 |---|---|---|---:|---|
+| Command to device | `<prefix>/<hostname>/command` | `<id> <command line>` | 1 | Must be false |
+| Response from device | `<prefix>/<hostname>/response` | `id=<id> OK`, `id=<id> Fail: ...`, or requested query output | 1 | No |
 | LNB asynchronous transition | `<prefix>/<hostname>/event/lnb` | Schema-1 LNB event fields | 1 | No |
 | Current LNB state | `<prefix>/<hostname>/state/lnb` | Schema-1 LNB state fields | 1 | Yes |
-| Positioner job transition | `<prefix>/<hostname>/event/diseqc` | v2 JSON job event | 1 | No |
-| Current positioner state | `<prefix>/<hostname>/state/diseqc` | v2 JSON state object | 1 | Yes |
+| DiSEqC motion transition | `<prefix>/<hostname>/event/diseqc` | Schema-1 motion event fields | 1 | No |
+| Current DiSEqC state | `<prefix>/<hostname>/state/diseqc` | Schema-1 motion state fields | 1 | Yes |
 | Device availability | `<prefix>/<hostname>/availability` | `online` or `offline` | 1 | Yes |
 
 The broker receives a retained `online` message after connection. The configured
 last will is retained `offline` at QoS 1.
 
-LNB and DiSEqC execution does not perform socket I/O. Events and state
+LNB and DiSEqC execution does not perform socket I/O. Responses, events, and state
 updates are placed in a bounded queue and published only by the MQTT worker. A
 broker failure, blocked publish, or full publication queue can lose MQTT output,
 but cannot delay or change completion of a hardware command.
 
-## Monitoring
+## Commands And Results
+
+Publish a command marked as MQTT-supported in
+[INTERFACE_COMMAND_MAP_V1.md](INTERFACE_COMMAND_MAP_V1.md) to
+`<prefix>/<hostname>/command`. Prefix the command with a requester-assigned decimal
+16-bit ID and one space. State-changing and action commands publish one terminal
+`id=<id> OK` response on success or one `id=<id> Fail: ...` response on failure.
+Queries may publish requested output lines before their terminal response. Each
+published line carries the same ID.
+
+Detailed current condition is owned by retained `state/<subsystem>` topics, while
+asynchronous transitions are owned by `event/<subsystem>`. The compact response
+only acknowledges whether the command completed successfully; it does not repeat
+state or health fields.
+
+Examples:
 
 ```bash
-mosquitto_sub -t 'diseqc/+/event/+' -t 'diseqc/+/state/+' -t 'diseqc/+/availability' -v
+mosquitto_sub -t 'diseqc/+/response' -t 'diseqc/+/event/+' -t 'diseqc/+/state/+' -t 'diseqc/+/availability' -v
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '41 show lnb a'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '42 lnb a pol v'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '43 diseqc goto 12'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '44 show capabilities'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '45 diseqc angle-limits 70 70'
+mosquitto_pub -q 1 -t 'diseqc/cubley-a1b2c3/command' -m '46 diseqc goto-angle east 12.3'
 ```
+
+The command line after the ID must be 1 to 64 ASCII bytes. The device rejects
+missing or out-of-range IDs, messages on an unexpected topic, empty or oversized
+payloads, and retained command messages. This prevents a stale retained command
+from executing after reconnect or reboot.
+
+QoS 1 can deliver a command more than once. The device caches the eight most
+recent `{id, command, responses}` transactions in RAM. Repeating the same ID and
+command replays the cached responses without executing the command again. Reusing
+a cached ID for different command text returns an ID-conflict failure. Requesters
+must therefore coordinate IDs when more than one publisher controls a device.
 
 ## Events And State
 
@@ -48,19 +81,41 @@ published.
 The GPIO callback only signals a worker; register inspection and MQTT publication
 run outside the interrupt callback.
 
-`state/lnb` is a retained snapshot published on connection, after each successful
-LNB control change, and after each fault transition. It begins with
+`state/lnb` is a retained snapshot published on connection, after each MQTT
+command, and after each fault transition. It begins with
 `schema=1 sub=lnb comp=state` and includes health, communication,
 fault, monitor and initialization state, register values, and channel polarization
 and band when available. Consumers should use `event/lnb` for live transitions
 and `state/lnb` to establish or recover current state.
 
-`event/diseqc` and `state/diseqc` carry the JSON job contract; see
-[DEVICE_API_V2.md](DEVICE_API_V2.md). The motion watchdog duration is still
-adjustable only from the USB console with `diseqc timeout <5..300>` (seconds,
-default 90); it is reported as `timeout_ms` in positioner state.
+`event/diseqc` reports motion start and completion transitions. The retained
+`state/diseqc` snapshot reports `stat`, `motion_id`, `operation`, `remaining_ms`,
+`completion`, `command_mode`, `requested_angle_deg`, `encoded_angle_deg`,
+`direction`, `movement_voltage_v`, `position_confidence`, `estimated_angle_deg`,
+`position_source`, `pending_target_deg`, `step_calibration_configured`,
+`east_step_deg`, `west_step_deg`, and `timeout_ms`.
+The retained state additionally carries `angle_limits_configured`,
+`east_limit_deg`, and `west_limit_deg`. Successful goto, step, and drive commands
+set the state busy. Further movement and raw transmit commands fail as busy until
+Halt, timeout, or `diseqc complete <motion_id>` releases the lock. The ID check
+prevents a stale external completion message from releasing a newer movement.
+`timeout_ms` reflects the configured motion watchdog auto-stop duration,
+adjustable with `diseqc timeout <5..300>` (seconds, default 90).
 
-The LNB schema uses `sub`, `comp`, `stat`, and `comm` for subsystem,
+Angular movement is fail-closed after boot. Before `diseqc goto-angle` can run,
+set volatile east/west bounds with `diseqc angle-limits <east> <west>` after
+confirming that both are inside the motor's adjusted hardware stops. The command
+accepts explicit direction plus unsigned decimal degrees and reports both the
+requested value and the value rounded to the protocol's tenth-degree GoToX
+encoding.
+Transmission records `pending_target_deg` while preserving any prior estimate.
+Matching external completion adopts the encoded GoToX target as
+`position_confidence=estimated`, not `rf_verified`. A step does the same only
+when direction-specific volatile step calibration is configured. Timeout sets
+`verification_failed`; continuous drive, stored/reference movement, Halt,
+uncalibrated step completion, and raw positioner commands set `unknown`.
+
+The compact schema uses `sub`, `comp`, `stat`, and `comm` for subsystem,
 component, status, and communication condition. Local diagnostic sequences use
 `seq`. Retained state omits health and fault sequence counters because they do not
 describe current condition.
@@ -118,12 +173,14 @@ cubley-a1b2c3(config*)# commit
 
 The broker must be set before an enabled configuration can be committed. Credentials
 are case-preserving but cannot contain spaces in schema v2. Password commands are
-redacted from debug logs and configuration output.
+redacted from debug logs and configuration output. MQTT messages containing
+configuration commands are rejected as unsupported.
 
 See [CONFIGURATION.md](CONFIGURATION.md) for the complete command list and
 [CONFIGURATION_STORAGE.md](CONFIGURATION_STORAGE.md) for the persisted schema.
 
 ## Scope
 
-There are no MQTT command or response topics. TLS, certificate management, and
-encrypted credential storage remain deferred.
+No JSON envelope or per-command topic contract is defined for the current MQTT
+transport. TLS, certificate management, and encrypted credential storage are also
+deferred.

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -474,7 +474,12 @@ namespace CubleyControl
                     "diseqc step",
                     east ? DiseqcCommandBuilder.BuildStepEast((byte)value) : DiseqcCommandBuilder.BuildStepWest((byte)value),
                     east ? "step_east" : "step_west",
-                    DiseqcStepBaseTimeMs + (value * DiseqcStepTimePerStepMs));
+                    DiseqcStepBaseTimeMs + (value * DiseqcStepTimePerStepMs),
+                    "step",
+                    "none",
+                    "none",
+                    east ? "east" : "west",
+                    value);
                 return;
             }
 

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -20,6 +20,7 @@ namespace CubleyControl
         private const int DiseqcMotionTimeoutMaxS = 300;
         private const int DiseqcStepBaseTimeMs = 1000;
         private const int DiseqcStepTimePerStepMs = 250;
+        private const int DiseqcMotorStoredPositionMax = 60;
 
         private const int PositionerOpGoto = 1;
         private const int PositionerOpStepEast = 2;
@@ -33,15 +34,22 @@ namespace CubleyControl
         private static int _diseqcCarrierDutyPercent;
         private static bool _diseqcTxBusy;
         private static DiseqcV1RoutePreset _diseqcRoutePreset = DiseqcV1RoutePreset.Direct;
-        // Motion state lives in the positioner job store (Program.Jobs.cs).
-        // Only the watchdog duration is configuration rather than job state.
+        private static readonly object _diseqcMotionLock = new object();
         private static int _diseqcMotionTimeoutMs = DiseqcMotionWorstCaseMs;
+        private static int _diseqcEastTravelLimitMicrodegrees;
+        private static int _diseqcWestTravelLimitMicrodegrees;
+        private static string _diseqcMotionCommandMode = "none";
+        private static string _diseqcMotionRequestedAngle = "none";
+        private static string _diseqcMotionEncodedAngle = "none";
+        private static string _diseqcMotionDirection = "none";
+        private static int _diseqcMotionVoltageV;
+        private static readonly DiseqcPositionEstimate _diseqcPositionEstimate = new DiseqcPositionEstimate();
 
         private static void HandleDiseqcCommand(string[] tokens, int reqId)
         {
             if (tokens.Length < 2)
             {
-                WriteCommandResult(reqId, false, "validation_error", "diseqc usage", "usage=diseqc <goto|step|drive|stop|preset|timeout|tx|tone|listen> ...");
+                WriteCommandResult(reqId, false, "validation_error", "diseqc usage", "usage=diseqc <goto|goto-angle|reference|store|recalculate|motor-limit|angle-limits|step-calibration|step|drive|stop|preset|timeout|tx|tone|listen> ...");
                 return;
             }
 
@@ -55,6 +63,18 @@ namespace CubleyControl
             if (verb == "timeout")
             {
                 HandleDiseqcTimeoutCommand(tokens, reqId);
+                return;
+            }
+
+            if (verb == "angle-limits")
+            {
+                HandleDiseqcAngleLimitsCommand(tokens, reqId);
+                return;
+            }
+
+            if (verb == "step-calibration")
+            {
+                HandleDiseqcStepCalibrationCommand(tokens, reqId);
                 return;
             }
 
@@ -87,6 +107,87 @@ namespace CubleyControl
                 return;
             }
 
+            if (verb == "motor-limit" && tokens.Length == 3)
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                byte[] frame;
+                if (tokens[2] == "off")
+                {
+                    frame = DiseqcCommandBuilder.BuildLimitsOff();
+                }
+                else if (tokens[2] == "east")
+                {
+                    frame = DiseqcCommandBuilder.BuildSetEastLimit();
+                }
+                else if (tokens[2] == "west")
+                {
+                    frame = DiseqcCommandBuilder.BuildSetWestLimit();
+                }
+                else
+                {
+                    WriteCommandResult(reqId, false, "validation_error", "diseqc motor-limit invalid", "usage=diseqc motor-limit <east|west|off>");
+                    return;
+                }
+
+                EmitDiseqcPositionerSettingResult(reqId, "diseqc motor-limit", frame);
+                return;
+            }
+
+            if (verb == "store" && tokens.Length == 3)
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                int position;
+                if (!TryParseByteDec(tokens[2], out position) || position < 1 || position > DiseqcMotorStoredPositionMax)
+                {
+                    WriteCommandResult(reqId, false, "validation_error", "diseqc store invalid", "position=" + tokens[2] + " range=1..60");
+                    return;
+                }
+
+                EmitDiseqcPositionerSettingResult(
+                    reqId,
+                    "diseqc store",
+                    DiseqcCommandBuilder.BuildStorePosition((byte)position));
+                return;
+            }
+
+            if (verb == "recalculate" && tokens.Length == 2)
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                EmitDiseqcPositionerSettingResult(
+                    reqId,
+                    "diseqc recalculate",
+                    DiseqcCommandBuilder.BuildRecalculatePositions());
+                return;
+            }
+
+            if (verb == "reference" && tokens.Length == 2)
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                EmitDiseqcPositionerTransmitResult(
+                    reqId,
+                    "diseqc reference",
+                    DiseqcCommandBuilder.BuildGotoStoredPosition(0),
+                    "goto_reference",
+                    _diseqcMotionTimeoutMs);
+                return;
+            }
+
             if (verb == "goto" && tokens.Length == 3)
             {
                 if (!EnsureDiseqcMotionIdle(reqId))
@@ -95,9 +196,9 @@ namespace CubleyControl
                 }
 
                 int position;
-                if (!TryParseByteDec(tokens[2], out position))
+                if (!TryParseByteDec(tokens[2], out position) || position > DiseqcMotorStoredPositionMax)
                 {
-                    WriteCommandResult(reqId, false, "validation_error", "diseqc goto invalid", "pos=" + tokens[2]);
+                    WriteCommandResult(reqId, false, "validation_error", "diseqc goto invalid", "position=" + tokens[2] + " range=0..60");
                     return;
                 }
 
@@ -106,8 +207,92 @@ namespace CubleyControl
                     reqId,
                     "diseqc goto",
                     frame,
-                    "goto",
+                    "goto_stored",
                     _diseqcMotionTimeoutMs);
+                return;
+            }
+
+            if (verb == "goto-angle" && tokens.Length == 4)
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                DiseqcMotorDirection direction;
+                if (tokens[2] == "east")
+                {
+                    direction = DiseqcMotorDirection.East;
+                }
+                else if (tokens[2] == "west")
+                {
+                    direction = DiseqcMotorDirection.West;
+                }
+                else
+                {
+                    WriteCommandResult(reqId, false, "validation_error", "diseqc goto-angle direction invalid", "direction=" + tokens[2]);
+                    return;
+                }
+
+                byte[] frame;
+                int requestedMicrodegrees;
+                int encodedAngleTenths;
+                string error;
+                if (!DiseqcCommandBuilder.TryBuildGotoAngularPosition(
+                    direction,
+                    tokens[3],
+                    out frame,
+                    out requestedMicrodegrees,
+                    out encodedAngleTenths,
+                    out error))
+                {
+                    WriteCommandResult(
+                        reqId,
+                        false,
+                        "validation_error",
+                        "diseqc goto-angle invalid",
+                        "angle=" + SanitizeToken(tokens[3]) + " reason=" + SanitizeToken(error));
+                    return;
+                }
+
+                int travelLimit = direction == DiseqcMotorDirection.East
+                    ? _diseqcEastTravelLimitMicrodegrees
+                    : _diseqcWestTravelLimitMicrodegrees;
+                if (travelLimit <= 0)
+                {
+                    WriteCommandResult(
+                        reqId,
+                        false,
+                        "validation_error",
+                        "diseqc angle limits not configured",
+                        "usage=diseqc angle-limits <east_degrees> <west_degrees>");
+                    return;
+                }
+
+                if (!DiseqcGotoAngleEncoder.IsWithinTravelLimit(requestedMicrodegrees, travelLimit))
+                {
+                    WriteCommandResult(
+                        reqId,
+                        false,
+                        "validation_error",
+                        "diseqc goto-angle exceeds software limit",
+                        "direction=" + tokens[2] +
+                        " requested_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees) +
+                        " limit_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(travelLimit));
+                    return;
+                }
+
+                EmitDiseqcPositionerTransmitResult(
+                    reqId,
+                    "diseqc goto-angle",
+                    frame,
+                    "goto_angle_" + tokens[2],
+                    _diseqcMotionTimeoutMs,
+                    "angular",
+                    DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees),
+                    DiseqcGotoAngleEncoder.FormatTenths(encodedAngleTenths),
+                    tokens[2],
+                    encodedAngleTenths * 100_000);
                 return;
             }
 
@@ -136,7 +321,17 @@ namespace CubleyControl
                     ? DiseqcCommandBuilder.BuildStepEast((byte)steps)
                     : DiseqcCommandBuilder.BuildStepWest((byte)steps);
                 int motionTimeMs = DiseqcStepBaseTimeMs + (steps * DiseqcStepTimePerStepMs);
-                EmitDiseqcPositionerTransmitResult(reqId, "diseqc step", frame, "step_" + dir, motionTimeMs);
+                EmitDiseqcPositionerTransmitResult(
+                    reqId,
+                    "diseqc step",
+                    frame,
+                    "step_" + dir,
+                    motionTimeMs,
+                    "step",
+                    "none",
+                    "none",
+                    dir,
+                    steps);
                 return;
             }
 
@@ -176,11 +371,68 @@ namespace CubleyControl
             WriteCommandResult(reqId, false, "validation_error", "diseqc syntax invalid", "verb=" + verb);
         }
 
-        /// <summary>
-        /// Typed entry point shared with the JSON transport. Mirrors the
-        /// console verbs in HandleDiseqcCommand without the tokenizing, so
-        /// both routes reach the same hardware path and the same job store.
-        /// </summary>
+        private static void HandleDiseqcStepCalibrationCommand(string[] tokens, int reqId)
+        {
+            if (tokens.Length == 3 && tokens[2] == "status")
+            {
+                WriteCommandResult(reqId, true, "ok", "diseqc step-calibration", BuildDiseqcPositionEstimateData());
+                return;
+            }
+
+            if (tokens.Length == 3 && tokens[2] == "off")
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                lock (_diseqcMotionLock)
+                {
+                    _diseqcPositionEstimate.ClearStepCalibration();
+                }
+
+                WriteCommandResult(reqId, true, "ok", "diseqc step-calibration disabled", BuildDiseqcPositionEstimateData());
+                return;
+            }
+
+            if (tokens.Length != 4)
+            {
+                WriteCommandResult(reqId, false, "validation_error", "diseqc step-calibration usage", "usage=diseqc step-calibration <status|off|east_deg west_deg>");
+                return;
+            }
+
+            int eastMicrodegrees;
+            int eastTenths;
+            string eastError;
+            int westMicrodegrees;
+            int westTenths;
+            string westError;
+            if (!DiseqcGotoAngleEncoder.TryParseDegrees(tokens[2], out eastMicrodegrees, out eastTenths, out eastError) ||
+                !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[3], out westMicrodegrees, out westTenths, out westError) ||
+                eastMicrodegrees <= 0 || westMicrodegrees <= 0)
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc step-calibration invalid",
+                    "east_step_deg=" + SanitizeToken(tokens[2]) + " west_step_deg=" + SanitizeToken(tokens[3]));
+                return;
+            }
+
+            if (!EnsureDiseqcMotionIdle(reqId))
+            {
+                return;
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                _diseqcPositionEstimate.ConfigureStepCalibration(eastMicrodegrees, westMicrodegrees);
+            }
+
+            WriteCommandResult(reqId, true, "ok", "diseqc step-calibration", BuildDiseqcPositionEstimateData());
+        }
+
         private static void RunPositionerOperation(int operation, int value)
         {
             int reqId = NextRequestId();
@@ -217,9 +469,7 @@ namespace CubleyControl
                 EmitDiseqcPositionerTransmitResult(
                     reqId,
                     "diseqc step",
-                    east
-                        ? DiseqcCommandBuilder.BuildStepEast((byte)value)
-                        : DiseqcCommandBuilder.BuildStepWest((byte)value),
+                    east ? DiseqcCommandBuilder.BuildStepEast((byte)value) : DiseqcCommandBuilder.BuildStepWest((byte)value),
                     east ? "step_east" : "step_west",
                     DiseqcStepBaseTimeMs + (value * DiseqcStepTimePerStepMs));
                 return;
@@ -238,12 +488,7 @@ namespace CubleyControl
                 return;
             }
 
-            WriteCommandResult(
-                reqId,
-                false,
-                "unsupported",
-                "unknown positioner operation",
-                "operation=" + operation.ToString());
+            WriteCommandResult(reqId, false, "unsupported", "unknown positioner operation", "operation=" + operation.ToString());
         }
 
         private static void EmitDiseqcShowSummaryLine()
@@ -260,18 +505,150 @@ namespace CubleyControl
                 out motionOperation,
                 out motionRemainingMs,
                 out motionCompletionSource);
-            WriteHumanHeading("DiSEqC");
-            WriteHumanField("Preset", DiseqcV1Presets.ToText(_diseqcRoutePreset));
-            WriteHumanField("Tone", toneEnabled ? "On" : "Off");
-            WriteHumanField("Frequency", toneEnabled ? _diseqcCarrierFrequencyHz.ToString() + " Hz" : "Not active");
-            WriteHumanField("Duty cycle", toneEnabled ? _diseqcCarrierDutyPercent.ToString() + "%" : "Not active");
-            WriteHumanField("Transmitter", _diseqcTxBusy ? "Busy" : "Idle");
-            WriteHumanField("Motion", motionBusy ? "Busy" : "Idle");
-            WriteHumanField("Motion ID", motionId == 0 ? "None" : motionId.ToString());
-            WriteHumanField("Operation", motionOperation);
-            WriteHumanField("Remaining", motionBusy ? ((motionRemainingMs + 999) / 1000).ToString() + " s" : "0 s");
-            WriteHumanField("Completion source", motionCompletionSource);
-            WriteHumanField("Watchdog timeout", (_diseqcMotionTimeoutMs / 1000).ToString() + " s");
+            string positionConfidence;
+            string estimatedAngle;
+            string positionSource;
+            string pendingTarget;
+            string eastStep;
+            string westStep;
+            lock (_diseqcMotionLock)
+            {
+                positionConfidence = _diseqcPositionEstimate.Confidence;
+                estimatedAngle = _diseqcPositionEstimate.HasEstimate
+                    ? FormatSignedDiseqcAngle(_diseqcPositionEstimate.EstimatedAngleMicrodegrees)
+                    : "Unknown";
+                positionSource = _diseqcPositionEstimate.Source;
+                pendingTarget = _diseqcPositionEstimate.HasPendingTarget
+                    ? FormatSignedDiseqcAngle(_diseqcPositionEstimate.PendingTargetMicrodegrees)
+                    : "None";
+                eastStep = _diseqcPositionEstimate.HasStepCalibration
+                    ? DiseqcGotoAngleEncoder.FormatMicrodegrees(_diseqcPositionEstimate.EastStepMicrodegrees)
+                    : "Disabled";
+                westStep = _diseqcPositionEstimate.HasStepCalibration
+                    ? DiseqcGotoAngleEncoder.FormatMicrodegrees(_diseqcPositionEstimate.WestStepMicrodegrees)
+                    : "Disabled";
+            }
+            if (_activeCommandTransport == CommandTransport.Usb)
+            {
+                WriteHumanHeading("DiSEqC");
+                WriteHumanField("Preset", DiseqcV1Presets.ToText(_diseqcRoutePreset));
+                WriteHumanField("Tone", toneEnabled ? "On" : "Off");
+                WriteHumanField("Frequency", toneEnabled ? _diseqcCarrierFrequencyHz.ToString() + " Hz" : "Not active");
+                WriteHumanField("Duty cycle", toneEnabled ? _diseqcCarrierDutyPercent.ToString() + "%" : "Not active");
+                WriteHumanField("Transmitter", _diseqcTxBusy ? "Busy" : "Idle");
+                WriteHumanField("Motion", motionBusy ? "Busy" : "Idle");
+                WriteHumanField("Motion ID", motionId == 0 ? "None" : motionId.ToString());
+                WriteHumanField("Operation", motionOperation);
+                WriteHumanField("Remaining", motionBusy ? ((motionRemainingMs + 999) / 1000).ToString() + " s" : "0 s");
+                WriteHumanField("Completion source", motionCompletionSource);
+                WriteHumanField("Command mode", _diseqcMotionCommandMode);
+                WriteHumanField("Direction", _diseqcMotionDirection);
+                WriteHumanField("Requested angle", _diseqcMotionRequestedAngle == "none" ? "Not applicable" : _diseqcMotionRequestedAngle + " deg");
+                WriteHumanField("Encoded angle", _diseqcMotionEncodedAngle == "none" ? "Not applicable" : _diseqcMotionEncodedAngle + " deg");
+                WriteHumanField("Movement voltage", _diseqcMotionVoltageV == 0 ? "Unknown" : _diseqcMotionVoltageV.ToString() + " V");
+                WriteHumanField("Estimated angle", estimatedAngle == "Unknown" ? estimatedAngle : estimatedAngle + " deg");
+                WriteHumanField("Position confidence", positionConfidence);
+                WriteHumanField("Position source", positionSource);
+                WriteHumanField("Pending target", pendingTarget == "None" ? pendingTarget : pendingTarget + " deg");
+                WriteHumanField("East step calibration", eastStep == "Disabled" ? eastStep : eastStep + " deg");
+                WriteHumanField("West step calibration", westStep == "Disabled" ? westStep : westStep + " deg");
+                WriteHumanField("East software limit", FormatDiseqcTravelLimit(_diseqcEastTravelLimitMicrodegrees));
+                WriteHumanField("West software limit", FormatDiseqcTravelLimit(_diseqcWestTravelLimitMicrodegrees));
+                WriteHumanField("Watchdog timeout", (_diseqcMotionTimeoutMs / 1000).ToString() + " s");
+                return;
+            }
+
+            _activeOutputSink(
+                "diseqc preset=" + DiseqcV1Presets.ToText(_diseqcRoutePreset) +
+                " tone=" + (toneEnabled ? "on" : "off") +
+                " frequency_hz=" + (toneEnabled ? _diseqcCarrierFrequencyHz.ToString() : "0") +
+                " duty_percent=" + (toneEnabled ? _diseqcCarrierDutyPercent.ToString() : "0") +
+                " tx_busy=" + (_diseqcTxBusy ? "1" : "0") +
+                " motion_busy=" + (motionBusy ? "1" : "0") +
+                " motion_id=" + motionId.ToString() +
+                " motion_operation=" + motionOperation +
+                " motion_remaining_ms=" + motionRemainingMs.ToString() +
+                " motion_completion=" + motionCompletionSource +
+                " " + BuildDiseqcMotionMetadataData() +
+                " " + BuildDiseqcTravelLimitsData() +
+                " motion_timeout_ms=" + _diseqcMotionTimeoutMs.ToString() +
+                "\r\n");
+        }
+
+        private static void HandleDiseqcAngleLimitsCommand(string[] tokens, int reqId)
+        {
+            if (tokens.Length == 3 && tokens[2] == "status")
+            {
+                WriteCommandResult(reqId, true, "ok", "diseqc angle-limits", BuildDiseqcTravelLimitsData());
+                return;
+            }
+
+            if (tokens.Length == 3 && tokens[2] == "off")
+            {
+                if (!EnsureDiseqcMotionIdle(reqId))
+                {
+                    return;
+                }
+
+                _diseqcEastTravelLimitMicrodegrees = 0;
+                _diseqcWestTravelLimitMicrodegrees = 0;
+                WriteCommandResult(reqId, true, "ok", "diseqc angle-limits disabled", BuildDiseqcTravelLimitsData());
+                return;
+            }
+
+            if (tokens.Length != 4)
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc angle-limits usage",
+                    "usage=diseqc angle-limits <status|off|east_degrees west_degrees>");
+                return;
+            }
+
+            int eastMicrodegrees;
+            int eastTenths;
+            string eastError;
+            int westMicrodegrees;
+            int westTenths;
+            string westError;
+            if (!DiseqcGotoAngleEncoder.TryParseDegrees(tokens[2], out eastMicrodegrees, out eastTenths, out eastError) ||
+                !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[3], out westMicrodegrees, out westTenths, out westError) ||
+                eastMicrodegrees <= 0 || westMicrodegrees <= 0)
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc angle-limits invalid",
+                    "east=" + SanitizeToken(tokens[2]) +
+                    " west=" + SanitizeToken(tokens[3]) +
+                    " max_deg=" + DiseqcLimits.GotoAngularMaxDegrees.ToString());
+                return;
+            }
+
+            if (!EnsureDiseqcMotionIdle(reqId))
+            {
+                return;
+            }
+
+            _diseqcEastTravelLimitMicrodegrees = eastMicrodegrees;
+            _diseqcWestTravelLimitMicrodegrees = westMicrodegrees;
+            WriteCommandResult(reqId, true, "ok", "diseqc angle-limits", BuildDiseqcTravelLimitsData());
+        }
+
+        private static string BuildDiseqcTravelLimitsData()
+        {
+            return "angle_limits_configured=" +
+                (_diseqcEastTravelLimitMicrodegrees > 0 && _diseqcWestTravelLimitMicrodegrees > 0 ? "1" : "0") +
+                " east_limit_deg=" + FormatDiseqcTravelLimit(_diseqcEastTravelLimitMicrodegrees) +
+                " west_limit_deg=" + FormatDiseqcTravelLimit(_diseqcWestTravelLimitMicrodegrees);
+        }
+
+        private static string FormatDiseqcTravelLimit(int microdegrees)
+        {
+            return microdegrees <= 0 ? "disabled" : DiseqcGotoAngleEncoder.FormatMicrodegrees(microdegrees);
         }
 
         private static void HandleDiseqcTimeoutCommand(string[] tokens, int reqId)
@@ -382,15 +759,31 @@ namespace CubleyControl
                 return;
             }
 
+            bool positionInvalidated = false;
+            if (IsRawPositionerCommand(frame))
+            {
+                lock (_diseqcMotionLock)
+                {
+                    _diseqcPositionEstimate.Invalidate();
+                }
+                positionInvalidated = true;
+            }
+
             WriteCommandResult(reqId, true, "ok", source, "bytes=" + BytesToHex(frame) + " encoded_bits=" + (frame.Length * 9).ToString());
+            if (positionInvalidated)
+            {
+                PublishMqttDiseqcState();
+            }
         }
 
-        private static void EmitDiseqcPositionerTransmitResult(
-            int reqId,
-            string source,
-            byte[] positionerFrame,
-            string motionOperation,
-            int motionDurationMs)
+        private static bool IsRawPositionerCommand(byte[] frame)
+        {
+            return frame != null && frame.Length >= 3 &&
+                (frame[1] == DiseqcAddress.AnyPositioner || frame[1] == DiseqcAddress.AnyPolarizerOrPositioner) &&
+                frame[2] >= DiseqcCommand.Halt && frame[2] <= DiseqcCommand.RecalculatePositions;
+        }
+
+        private static void EmitDiseqcPositionerSettingResult(int reqId, string source, byte[] positionerFrame)
         {
             string error;
             byte[][] prefixFrames;
@@ -408,7 +801,88 @@ namespace CubleyControl
                     return;
                 }
 
-                CompleteOrBeginDiseqcMotion(motionOperation, motionDurationMs);
+                WriteCommandResult(reqId, true, "ok", source, "bytes=" + BytesToHex(positionerFrame));
+                return;
+            }
+
+            byte[][] sequence = new byte[prefixFrames.Length + 1][];
+            for (int i = 0; i < prefixFrames.Length; i++)
+            {
+                sequence[i] = prefixFrames[i];
+            }
+
+            sequence[prefixFrames.Length] = positionerFrame;
+            if (!TryTransmitDiseqcSequence(sequence, out error))
+            {
+                WriteCommandResult(reqId, false, "hw_fault", source + " failed", "reason=" + SanitizeToken(error));
+                return;
+            }
+
+            WriteCommandResult(
+                reqId,
+                true,
+                "ok",
+                source,
+                "preset=" + DiseqcV1Presets.ToText(_diseqcRoutePreset) + " bytes=" + BytesToHex(positionerFrame));
+        }
+
+        private static void EmitDiseqcPositionerTransmitResult(
+            int reqId,
+            string source,
+            byte[] positionerFrame,
+            string motionOperation,
+            int motionDurationMs)
+        {
+            EmitDiseqcPositionerTransmitResult(
+                reqId,
+                source,
+                positionerFrame,
+                motionOperation,
+                motionDurationMs,
+                motionOperation == null ? "halt" : motionOperation,
+                "none",
+                "none",
+                MotionDirectionFromOperation(motionOperation),
+                0);
+        }
+
+        private static void EmitDiseqcPositionerTransmitResult(
+            int reqId,
+            string source,
+            byte[] positionerFrame,
+            string motionOperation,
+            int motionDurationMs,
+            string commandMode,
+            string requestedAngle,
+            string encodedAngle,
+            string direction,
+            int positionValue)
+        {
+            string error;
+            byte[][] prefixFrames;
+            if (!TryBuildPresetPrefixFrames(out prefixFrames, out error))
+            {
+                WriteCommandResult(reqId, false, "hw_fault", source + " failed", "reason=" + SanitizeToken(error));
+                return;
+            }
+
+            if (prefixFrames.Length == 0)
+            {
+                if (!TryTransmitDiseqcFrame(positionerFrame, out error))
+                {
+                    WriteCommandResult(reqId, false, "hw_fault", source + " failed", "reason=" + SanitizeToken(error));
+                    return;
+                }
+
+                CompleteOrBeginDiseqcMotion(
+                    motionOperation,
+                    motionDurationMs,
+                    commandMode,
+                    requestedAngle,
+                    encodedAngle,
+                    direction,
+                    GetDiseqcMotionVoltageV(),
+                    positionValue);
                 WriteCommandResult(
                     reqId,
                     true,
@@ -434,7 +908,15 @@ namespace CubleyControl
                 return;
             }
 
-            CompleteOrBeginDiseqcMotion(motionOperation, motionDurationMs);
+            CompleteOrBeginDiseqcMotion(
+                motionOperation,
+                motionDurationMs,
+                commandMode,
+                requestedAngle,
+                encodedAngle,
+                direction,
+                GetDiseqcMotionVoltageV(),
+                positionValue);
 
             WriteCommandResult(
                 reqId,
@@ -447,10 +929,42 @@ namespace CubleyControl
                 BuildDiseqcMotionResultData());
         }
 
+        private static string MotionDirectionFromOperation(string operation)
+        {
+            if (operation == null)
+            {
+                return "none";
+            }
+
+            if (operation.IndexOf("east") >= 0)
+            {
+                return "east";
+            }
+
+            if (operation.IndexOf("west") >= 0)
+            {
+                return "west";
+            }
+
+            return "none";
+        }
+
+        private static int GetDiseqcMotionVoltageV()
+        {
+            if (!EnsureLnbInitialized())
+            {
+                return 0;
+            }
+
+            return LNBH26.NativeGetPolarizationForChannel(LnbChannelA) == (int)LNBH26.Polarization.Horizontal
+                ? 18
+                : 13;
+        }
+
         private static bool EnsureDiseqcMotionIdle(int reqId)
         {
-            int activeJobId = GetActiveDiseqcJobId();
-            if (activeJobId == 0)
+            int motionId = GetActiveDiseqcJobId();
+            if (motionId == 0)
             {
                 return true;
             }
@@ -460,15 +974,15 @@ namespace CubleyControl
             int remainingMs;
             int timeoutMs;
             string detail;
-            TryGetDiseqcJobSnapshot(activeJobId, out operation, out state, out remainingMs, out timeoutMs, out detail);
+            TryGetDiseqcJobSnapshot(motionId, out operation, out state, out remainingMs, out timeoutMs, out detail);
+            _blockingDiseqcJobId = motionId;
 
-            _blockingDiseqcJobId = activeJobId;
             WriteCommandResult(
                 reqId,
                 false,
                 "busy",
                 "diseqc motion busy",
-                "motion_id=" + activeJobId.ToString() +
+                "motion_id=" + motionId.ToString() +
                 " operation=" + operation +
                 " remaining_ms=" + remainingMs.ToString());
             return false;
@@ -490,43 +1004,71 @@ namespace CubleyControl
                 return;
             }
 
-            if (activeJobId != requestedMotionId)
-            {
-                WriteCommandResult(
-                    reqId,
-                    false,
-                    "validation_error",
-                    "diseqc motion id mismatch",
-                    "motion_id=" + activeJobId.ToString());
-                return;
-            }
-
-            if (!TryEndDiseqcJob(requestedMotionId, JobStateReleased, string.Empty))
+            if (activeJobId != requestedMotionId ||
+                !TryEndDiseqcJob(requestedMotionId, JobStateReleased, string.Empty))
             {
                 WriteCommandResult(reqId, false, "validation_error", "diseqc motion id mismatch", "motion_id=" + activeJobId.ToString());
                 return;
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                _diseqcPositionEstimate.CompletePending();
             }
 
             PublishMqttDiseqcJobTransition("end", requestedMotionId);
             WriteCommandResult(reqId, true, "ok", "diseqc complete", "motion_id=" + requestedMotionId.ToString());
         }
 
-        /// <summary>
-        /// A null <paramref name="operation"/> means the transmitted frame was
-        /// a Halt, which ends any running job rather than starting one.
-        /// </summary>
-        private static void CompleteOrBeginDiseqcMotion(string operation, int durationMs)
+        private static void CompleteOrBeginDiseqcMotion(
+            string operation,
+            int durationMs,
+            string commandMode,
+            string requestedAngle,
+            string encodedAngle,
+            string direction,
+            int voltageV,
+            int positionValue)
         {
             if (operation == null)
             {
                 int haltedJobId = EndActiveDiseqcJob(JobStateHalted, string.Empty);
+                lock (_diseqcMotionLock)
+                {
+                    _diseqcPositionEstimate.Invalidate();
+                }
+
                 if (haltedJobId != 0)
                 {
                     _lastStartedDiseqcJobId = haltedJobId;
                     PublishMqttDiseqcJobTransition("end", haltedJobId);
                 }
-
                 return;
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                _diseqcMotionCommandMode = commandMode;
+                _diseqcMotionRequestedAngle = requestedAngle;
+                _diseqcMotionEncodedAngle = encodedAngle;
+                _diseqcMotionDirection = direction;
+                _diseqcMotionVoltageV = voltageV;
+                if (commandMode == "angular")
+                {
+                    _diseqcPositionEstimate.BeginGotoAngular(
+                        direction == "east" ? DiseqcMotorDirection.East : DiseqcMotorDirection.West,
+                        positionValue);
+                }
+                else if (commandMode == "step")
+                {
+                    _diseqcPositionEstimate.BeginStep(
+                        direction == "east" ? DiseqcMotorDirection.East : DiseqcMotorDirection.West,
+                        positionValue);
+                }
+                else
+                {
+                    _diseqcPositionEstimate.Invalidate();
+                }
             }
 
             int jobId = BeginDiseqcJob(operation, durationMs);
@@ -544,7 +1086,55 @@ namespace CubleyControl
             GetDiseqcMotionSnapshot(out busy, out motionId, out operation, out remainingMs, out completionSource);
             return " motion_busy=" + (busy ? "1" : "0") +
                 " motion_id=" + motionId.ToString() +
-                " motion_remaining_ms=" + remainingMs.ToString();
+                " motion_remaining_ms=" + remainingMs.ToString() +
+                " " + BuildDiseqcMotionMetadataData();
+        }
+
+        private static string BuildDiseqcMotionMetadataData()
+        {
+            lock (_diseqcMotionLock)
+            {
+                return "command_mode=" + _diseqcMotionCommandMode +
+                    " requested_angle_deg=" + _diseqcMotionRequestedAngle +
+                    " encoded_angle_deg=" + _diseqcMotionEncodedAngle +
+                    " direction=" + _diseqcMotionDirection +
+                    " movement_voltage_v=" + (_diseqcMotionVoltageV == 0 ? "unknown" : _diseqcMotionVoltageV.ToString()) +
+                    " " + BuildDiseqcPositionEstimateDataLocked();
+            }
+        }
+
+        private static string BuildDiseqcPositionEstimateData()
+        {
+            lock (_diseqcMotionLock)
+            {
+                return BuildDiseqcPositionEstimateDataLocked();
+            }
+        }
+
+        private static string BuildDiseqcPositionEstimateDataLocked()
+        {
+            return "position_confidence=" + _diseqcPositionEstimate.Confidence +
+                " estimated_angle_deg=" + (_diseqcPositionEstimate.HasEstimate
+                    ? FormatSignedDiseqcAngle(_diseqcPositionEstimate.EstimatedAngleMicrodegrees)
+                    : "unknown") +
+                " position_source=" + _diseqcPositionEstimate.Source +
+                " pending_target_deg=" + (_diseqcPositionEstimate.HasPendingTarget
+                    ? FormatSignedDiseqcAngle(_diseqcPositionEstimate.PendingTargetMicrodegrees)
+                    : "none") +
+                " step_calibration_configured=" + (_diseqcPositionEstimate.HasStepCalibration ? "1" : "0") +
+                " east_step_deg=" + (_diseqcPositionEstimate.HasStepCalibration
+                    ? DiseqcGotoAngleEncoder.FormatMicrodegrees(_diseqcPositionEstimate.EastStepMicrodegrees)
+                    : "none") +
+                " west_step_deg=" + (_diseqcPositionEstimate.HasStepCalibration
+                    ? DiseqcGotoAngleEncoder.FormatMicrodegrees(_diseqcPositionEstimate.WestStepMicrodegrees)
+                    : "none");
+        }
+
+        private static string FormatSignedDiseqcAngle(int signedMicrodegrees)
+        {
+            return signedMicrodegrees < 0
+                ? "-" + DiseqcGotoAngleEncoder.FormatMicrodegrees(-signedMicrodegrees)
+                : DiseqcGotoAngleEncoder.FormatMicrodegrees(signedMicrodegrees);
         }
 
         private static void DiseqcMotionMonitorLoop()
@@ -553,8 +1143,8 @@ namespace CubleyControl
             {
                 Thread.Sleep(DiseqcMotionPollIntervalMs);
 
-                int expiredJobId = GetExpiredDiseqcJobId();
-                if (expiredJobId == 0)
+                int expiredMotionId = GetExpiredDiseqcJobId();
+                if (expiredMotionId == 0)
                 {
                     continue;
                 }
@@ -562,9 +1152,7 @@ namespace CubleyControl
                 bool ended;
                 lock (_commandLock)
                 {
-                    // Re-check under the command lock: the job may have been
-                    // halted or released while this loop was waiting for it.
-                    if (GetExpiredDiseqcJobId() != expiredJobId)
+                    if (GetExpiredDiseqcJobId() != expiredMotionId)
                     {
                         continue;
                     }
@@ -583,14 +1171,19 @@ namespace CubleyControl
                         EndLnbIoOperation();
                     }
 
+                    lock (_diseqcMotionLock)
+                    {
+                        _diseqcPositionEstimate.FailVerification();
+                    }
+
                     ended = error.Length == 0
-                        ? TryEndDiseqcJob(expiredJobId, JobStateTimeout, string.Empty)
-                        : TryEndDiseqcJob(expiredJobId, JobStateTimeoutHaltFailed, SanitizeToken(error));
+                        ? TryEndDiseqcJob(expiredMotionId, JobStateTimeout, string.Empty)
+                        : TryEndDiseqcJob(expiredMotionId, JobStateTimeoutHaltFailed, SanitizeToken(error));
                 }
 
                 if (ended)
                 {
-                    PublishMqttDiseqcJobTransition("end", expiredJobId);
+                    PublishMqttDiseqcJobTransition("end", expiredMotionId);
                 }
             }
         }

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -43,6 +43,9 @@ namespace CubleyControl
         private static string _diseqcMotionEncodedAngle = "none";
         private static string _diseqcMotionDirection = "none";
         private static int _diseqcMotionVoltageV;
+        private static bool _diseqcMotionVoltageOverrideActive;
+        private static int _diseqcMotionRestorePolarization;
+        private static string _diseqcMotionVoltageRestoreError = string.Empty;
         private static readonly DiseqcPositionEstimate _diseqcPositionEstimate = new DiseqcPositionEstimate();
 
         private static void HandleDiseqcCommand(string[] tokens, int reqId)
@@ -866,14 +869,28 @@ namespace CubleyControl
                 return;
             }
 
+            int restorePolarization = (int)LNBH26.Polarization.Horizontal;
+            bool voltageOverridden = false;
+            if (motionOperation != null &&
+                !TryPrepareDiseqcMotionVoltage(out restorePolarization, out voltageOverridden, out error))
+            {
+                WriteCommandResult(reqId, false, "hw_fault", source + " failed", "reason=" + SanitizeToken(error));
+                return;
+            }
+
             if (prefixFrames.Length == 0)
             {
                 if (!TryTransmitDiseqcFrame(positionerFrame, out error))
                 {
+                    AppendDiseqcMotionVoltageRollbackError(
+                        restorePolarization,
+                        voltageOverridden,
+                        ref error);
                     WriteCommandResult(reqId, false, "hw_fault", source + " failed", "reason=" + SanitizeToken(error));
                     return;
                 }
 
+                CommitDiseqcMotionVoltageOverride(restorePolarization, voltageOverridden);
                 CompleteOrBeginDiseqcMotion(
                     motionOperation,
                     motionDurationMs,
@@ -904,10 +921,15 @@ namespace CubleyControl
 
             if (!TryTransmitDiseqcSequence(sequence, out error))
             {
+                AppendDiseqcMotionVoltageRollbackError(
+                    restorePolarization,
+                    voltageOverridden,
+                    ref error);
                 WriteCommandResult(reqId, false, "hw_fault", source + " failed", "reason=" + SanitizeToken(error));
                 return;
             }
 
+            CommitDiseqcMotionVoltageOverride(restorePolarization, voltageOverridden);
             CompleteOrBeginDiseqcMotion(
                 motionOperation,
                 motionDurationMs,
@@ -959,6 +981,120 @@ namespace CubleyControl
             return LNBH26.NativeGetPolarizationForChannel(LnbChannelA) == (int)LNBH26.Polarization.Horizontal
                 ? 18
                 : 13;
+        }
+
+        private static bool TryPrepareDiseqcMotionVoltage(
+            out int restorePolarization,
+            out bool voltageOverridden,
+            out string error)
+        {
+            voltageOverridden = false;
+            error = string.Empty;
+
+            lock (_lnbIoLock)
+            {
+                restorePolarization = LNBH26.NativeGetPolarizationForChannel(LnbChannelA);
+                if (restorePolarization != (int)LNBH26.Polarization.Vertical &&
+                    restorePolarization != (int)LNBH26.Polarization.Horizontal)
+                {
+                    error = "lnb_polarization_read_" + restorePolarization.ToString();
+                    return false;
+                }
+
+                if (restorePolarization == (int)LNBH26.Polarization.Horizontal)
+                {
+                    return true;
+                }
+
+                int rc = LNBH26.NativeSetPolarizationForChannel(
+                    LnbChannelA,
+                    (int)LNBH26.Polarization.Horizontal);
+                if (rc != (int)LNBH26.Status.Ok)
+                {
+                    error = "lnb_motor_voltage_" + rc.ToString();
+                    return false;
+                }
+            }
+
+            voltageOverridden = true;
+            return true;
+        }
+
+        private static void AppendDiseqcMotionVoltageRollbackError(
+            int restorePolarization,
+            bool voltageOverridden,
+            ref string error)
+        {
+            if (!voltageOverridden)
+            {
+                return;
+            }
+
+            int rc;
+            lock (_lnbIoLock)
+            {
+                rc = LNBH26.NativeSetPolarizationForChannel(LnbChannelA, restorePolarization);
+            }
+
+            if (rc != (int)LNBH26.Status.Ok)
+            {
+                error += "_voltage_restore_" + rc.ToString();
+            }
+        }
+
+        private static void CommitDiseqcMotionVoltageOverride(int restorePolarization, bool voltageOverridden)
+        {
+            if (!voltageOverridden)
+            {
+                return;
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                _diseqcMotionRestorePolarization = restorePolarization;
+                _diseqcMotionVoltageOverrideActive = true;
+                _diseqcMotionVoltageRestoreError = string.Empty;
+            }
+        }
+
+        private static void RestoreDiseqcMotionVoltageAfterJob()
+        {
+            int restorePolarization;
+            lock (_diseqcMotionLock)
+            {
+                if (!_diseqcMotionVoltageOverrideActive)
+                {
+                    return;
+                }
+
+                restorePolarization = _diseqcMotionRestorePolarization;
+            }
+
+            int rc;
+            lock (_lnbIoLock)
+            {
+                rc = LNBH26.NativeSetPolarizationForChannel(LnbChannelA, restorePolarization);
+            }
+
+            if (rc == (int)LNBH26.Status.Ok)
+            {
+                lock (_diseqcMotionLock)
+                {
+                    _diseqcMotionVoltageOverrideActive = false;
+                    _diseqcMotionVoltageRestoreError = string.Empty;
+                }
+                return;
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                _diseqcMotionVoltageRestoreError = "native_" + rc.ToString();
+            }
+
+            WriteStructuredDebug(
+                "DISEQC",
+                "schema=1 sub=diseqc comp=control operation=restore_motor_voltage" +
+                " stat=error rc=" + rc.ToString() + " level=error");
         }
 
         private static bool EnsureDiseqcMotionIdle(int reqId)
@@ -1099,6 +1235,10 @@ namespace CubleyControl
                     " encoded_angle_deg=" + _diseqcMotionEncodedAngle +
                     " direction=" + _diseqcMotionDirection +
                     " movement_voltage_v=" + (_diseqcMotionVoltageV == 0 ? "unknown" : _diseqcMotionVoltageV.ToString()) +
+                    " motor_voltage_override_active=" + (_diseqcMotionVoltageOverrideActive ? "1" : "0") +
+                    " motor_voltage_restore_error=" + (_diseqcMotionVoltageRestoreError.Length == 0
+                        ? "none"
+                        : _diseqcMotionVoltageRestoreError) +
                     " " + BuildDiseqcPositionEstimateDataLocked();
             }
         }

--- a/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
@@ -355,9 +355,10 @@ namespace CubleyControl
                 }
 
                 int position;
-                if (!command.TryGetInt("position", out position) || position < 0 || position > 255)
+                if (!command.TryGetInt("position", out position) ||
+                    position < 0 || position > DiseqcMotorStoredPositionMax)
                 {
-                    return BuildMqttFailureBody(commandId, "validation_error", "position must be an integer 0 to 255", 0);
+                    return BuildMqttFailureBody(commandId, "validation_error", "position must be an integer 0 to 60", 0);
                 }
 
                 operation = PositionerOpGoto;

--- a/software/nanoFramework/CubleyControl/Program.Jobs.cs
+++ b/software/nanoFramework/CubleyControl/Program.Jobs.cs
@@ -77,6 +77,7 @@ namespace CubleyControl
         /// </summary>
         private static bool TryEndDiseqcJob(int jobId, string state, string detail)
         {
+            bool ended;
             lock (_diseqcJobLock)
             {
                 if (jobId == 0 || _diseqcActiveJobId != jobId)
@@ -99,8 +100,15 @@ namespace CubleyControl
                 _diseqcJobDeadlines[slot] = 0;
                 _diseqcActiveJobId = 0;
                 _diseqcLastTerminalJobId = jobId;
-                return true;
+                ended = true;
             }
+
+            if (ended)
+            {
+                RestoreDiseqcMotionVoltageAfterJob();
+            }
+
+            return ended;
         }
 
         /// <summary>Ends whichever job is active. Returns its id, or 0 if none was.</summary>

--- a/software/nanoFramework/CubleyControl/packages.config
+++ b/software/nanoFramework/CubleyControl/packages.config
@@ -10,4 +10,5 @@
   <package id="nanoFramework.System.Collections" version="1.5.75" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.64" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
 </packages>

--- a/software/nanoFramework/CubleyDiseqc.Managed/CubleyDiseqc.Managed.nfproj
+++ b/software/nanoFramework/CubleyDiseqc.Managed/CubleyDiseqc.Managed.nfproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <Compile Include="DiseqcCommandBuilder.cs" />
     <Compile Include="DiseqcFrameCodec.cs" />
+    <Compile Include="DiseqcGotoAngleEncoder.cs" />
+    <Compile Include="DiseqcPositionEstimate.cs" />
     <Compile Include="DiseqcProtocol.cs" />
     <Compile Include="DiseqcV1Presets.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcCommandBuilder.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcCommandBuilder.cs
@@ -5,6 +5,22 @@ namespace Cubley.Diseqc
         // Command byte high nibble for Write N0/N1 uses option bits in the low nibble.
         private const byte SwitchOptionBase = 0xF0;
 
+        public static byte[] BuildRaw(byte[] frame)
+        {
+            if (frame == null)
+            {
+                return new byte[0];
+            }
+
+            byte[] copy = new byte[frame.Length];
+            for (int i = 0; i < frame.Length; i++)
+            {
+                copy[i] = frame[i];
+            }
+
+            return copy;
+        }
+
         public static byte[] BuildFrame(DiseqcFraming framing, byte address, byte command)
         {
             return new byte[] { (byte)framing, address, command };
@@ -18,6 +34,21 @@ namespace Cubley.Diseqc
         public static byte[] BuildHalt()
         {
             return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.Halt);
+        }
+
+        public static byte[] BuildLimitsOff()
+        {
+            return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.LimitsOff);
+        }
+
+        public static byte[] BuildSetEastLimit()
+        {
+            return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.SetEastLimit);
+        }
+
+        public static byte[] BuildSetWestLimit()
+        {
+            return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.SetWestLimit);
         }
 
         public static byte[] BuildDriveEast()
@@ -40,9 +71,41 @@ namespace Cubley.Diseqc
             return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.DriveWestOrStep, NormalizeSteps(steps));
         }
 
+        public static byte[] BuildStorePosition(byte position)
+        {
+            return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.StorePosition, position);
+        }
+
         public static byte[] BuildGotoStoredPosition(byte position)
         {
             return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.GotoStoredPosition, position);
+        }
+
+        public static byte[] BuildRecalculatePositions()
+        {
+            return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyPolarizerOrPositioner, DiseqcCommand.RecalculatePositions, 0x00);
+        }
+
+        public static bool TryBuildGotoAngularPosition(
+            DiseqcMotorDirection direction,
+            string degrees,
+            out byte[] frame,
+            out int requestedMicrodegrees,
+            out int encodedAngleTenths,
+            out string error)
+        {
+            return DiseqcGotoAngleEncoder.TryBuildFrame(
+                direction,
+                degrees,
+                out frame,
+                out requestedMicrodegrees,
+                out encodedAngleTenths,
+                out error);
+        }
+
+        public static byte[] BuildWritePortGroupN0(byte option)
+        {
+            return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyLnbSwitchSmatv, DiseqcCommand.WriteN0, option);
         }
 
         // DiSEqC 1.0 committed switch control (port/pol/band matrix).
@@ -104,6 +167,53 @@ namespace Cubley.Diseqc
                 BuildUncommittedSwitch(uncommittedInputIndex),
                 BuildCommittedSwitch(position, option, polarization, band),
             };
+        }
+
+        public static byte[] BuildPositionerHalt()
+        {
+            return BuildHalt();
+        }
+
+        public static byte[] BuildPositionerDriveEast()
+        {
+            return BuildDriveEast();
+        }
+
+        public static byte[] BuildPositionerDriveWest()
+        {
+            return BuildDriveWest();
+        }
+
+        public static byte[] BuildPositionerStepEast(byte steps)
+        {
+            return BuildStepEast(steps);
+        }
+
+        public static byte[] BuildPositionerStepWest(byte steps)
+        {
+            return BuildStepWest(steps);
+        }
+
+        public static byte[] BuildPositionerGotoStoredPosition(byte position)
+        {
+            return BuildGotoStoredPosition(position);
+        }
+
+        public static bool TryBuildPositionerGotoAngularPosition(
+            DiseqcMotorDirection direction,
+            string degrees,
+            out byte[] frame,
+            out int requestedMicrodegrees,
+            out int encodedAngleTenths,
+            out string error)
+        {
+            return TryBuildGotoAngularPosition(
+                direction,
+                degrees,
+                out frame,
+                out requestedMicrodegrees,
+                out encodedAngleTenths,
+                out error);
         }
 
         private static byte NormalizeSteps(byte steps)

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcGotoAngleEncoder.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcGotoAngleEncoder.cs
@@ -1,0 +1,189 @@
+namespace Cubley.Diseqc
+{
+    // Encodes command 0x6E using the DiSEqC GoToX degree nibbles and the
+    // specified fractional-degree lookup. Decimal text is parsed without
+    // floating point so host and nanoFramework builds quantize identically.
+    public static class DiseqcGotoAngleEncoder
+    {
+        private const int MicrodegreesPerDegree = 1_000_000;
+        private const int TenthsPerDegree = 10;
+        private static readonly byte[] FractionCodeByTenth =
+            { 0x00, 0x02, 0x03, 0x05, 0x06, 0x08, 0x0A, 0x0B, 0x0D, 0x0E };
+
+        public static bool TryBuildFrame(
+            DiseqcMotorDirection direction,
+            string degrees,
+            out byte[] frame,
+            out int requestedMicrodegrees,
+            out int encodedAngleTenths,
+            out string error)
+        {
+            frame = new byte[0];
+            requestedMicrodegrees = 0;
+            encodedAngleTenths = 0;
+            error = string.Empty;
+
+            if (direction != DiseqcMotorDirection.East && direction != DiseqcMotorDirection.West)
+            {
+                error = "invalid_direction";
+                return false;
+            }
+
+            if (!TryParseDegrees(degrees, out requestedMicrodegrees, out encodedAngleTenths, out error))
+            {
+                return false;
+            }
+
+            int directionWord = direction == DiseqcMotorDirection.East ? 0xE000 : 0xD000;
+            int wholeDegrees = encodedAngleTenths / TenthsPerDegree;
+            int fractionalTenth = encodedAngleTenths % TenthsPerDegree;
+            int positionWord = directionWord | (wholeDegrees << 4) | FractionCodeByTenth[fractionalTenth];
+            frame = new byte[]
+            {
+                (byte)DiseqcFraming.FirstTransmissionNoReply,
+                DiseqcAddress.AnyPolarizerOrPositioner,
+                DiseqcCommand.GotoAngularPosition,
+                (byte)(positionWord >> 8),
+                (byte)positionWord,
+            };
+
+            return true;
+        }
+
+        public static bool TryParseDegrees(
+            string text,
+            out int requestedMicrodegrees,
+            out int encodedAngleTenths,
+            out string error)
+        {
+            requestedMicrodegrees = 0;
+            encodedAngleTenths = 0;
+            error = string.Empty;
+
+            if (string.IsNullOrEmpty(text))
+            {
+                error = "angle_empty";
+                return false;
+            }
+
+            int decimalIndex = -1;
+            int wholeDegrees = 0;
+            int fractionalMicrodegrees = 0;
+            int fractionalDigits = 0;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char value = text[i];
+                if (value == '.')
+                {
+                    if (decimalIndex >= 0 || i == 0 || i == text.Length - 1)
+                    {
+                        error = "angle_format";
+                        return false;
+                    }
+
+                    decimalIndex = i;
+                    continue;
+                }
+
+                if (value < '0' || value > '9')
+                {
+                    error = "angle_format";
+                    return false;
+                }
+
+                int digit = value - '0';
+                if (decimalIndex < 0)
+                {
+                    wholeDegrees = (wholeDegrees * 10) + digit;
+                    if (wholeDegrees > DiseqcLimits.GotoAngularMaxDegrees)
+                    {
+                        error = "angle_out_of_range";
+                        return false;
+                    }
+                }
+                else
+                {
+                    fractionalDigits++;
+                    if (fractionalDigits > 6)
+                    {
+                        error = "angle_precision";
+                        return false;
+                    }
+
+                    fractionalMicrodegrees = (fractionalMicrodegrees * 10) + digit;
+                }
+            }
+
+            while (fractionalDigits < 6)
+            {
+                fractionalMicrodegrees *= 10;
+                fractionalDigits++;
+            }
+
+            requestedMicrodegrees = (wholeDegrees * MicrodegreesPerDegree) + fractionalMicrodegrees;
+            if (requestedMicrodegrees > DiseqcLimits.GotoAngularMaxDegrees * MicrodegreesPerDegree)
+            {
+                requestedMicrodegrees = 0;
+                error = "angle_out_of_range";
+                return false;
+            }
+
+            long scaled = ((long)requestedMicrodegrees * TenthsPerDegree) +
+                (MicrodegreesPerDegree / 2);
+            encodedAngleTenths = (int)(scaled / MicrodegreesPerDegree);
+            if (encodedAngleTenths > DiseqcLimits.GotoAngularMaxDegrees * TenthsPerDegree)
+            {
+                requestedMicrodegrees = 0;
+                encodedAngleTenths = 0;
+                error = "angle_out_of_range";
+                return false;
+            }
+
+            return true;
+        }
+
+        public static string FormatMicrodegrees(int microdegrees)
+        {
+            int whole = microdegrees / MicrodegreesPerDegree;
+            int fraction = microdegrees % MicrodegreesPerDegree;
+            if (fraction == 0)
+            {
+                return whole.ToString();
+            }
+
+            string fractionText = fraction.ToString();
+            while (fractionText.Length < 6)
+            {
+                fractionText = "0" + fractionText;
+            }
+
+            int end = fractionText.Length;
+            while (end > 0 && fractionText[end - 1] == '0')
+            {
+                end--;
+            }
+
+            return whole.ToString() + "." + fractionText.Substring(0, end);
+        }
+
+        public static bool IsWithinTravelLimit(int requestedMicrodegrees, int limitMicrodegrees)
+        {
+            return requestedMicrodegrees >= 0 &&
+                limitMicrodegrees > 0 &&
+                requestedMicrodegrees <= limitMicrodegrees;
+        }
+
+        public static string FormatTenths(int tenths)
+        {
+            int whole = tenths / TenthsPerDegree;
+            int remainder = tenths % TenthsPerDegree;
+            if (remainder == 0)
+            {
+                return whole.ToString();
+            }
+
+            return whole.ToString() + "." + remainder.ToString();
+        }
+    }
+}

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcPositionEstimate.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcPositionEstimate.cs
@@ -68,17 +68,17 @@ namespace Cubley.Diseqc
             int stepSize = direction == DiseqcMotorDirection.East
                 ? EastStepMicrodegrees
                 : WestStepMicrodegrees;
-            int signedDelta = direction == DiseqcMotorDirection.East
-                ? stepSize * steps
-                : -(stepSize * steps);
-            int target = EstimatedAngleMicrodegrees + signedDelta;
+            long signedDelta = direction == DiseqcMotorDirection.East
+                ? (long)stepSize * steps
+                : -((long)stepSize * steps);
+            long target = (long)EstimatedAngleMicrodegrees + signedDelta;
             if (target < -MaximumMagnitudeMicrodegrees || target > MaximumMagnitudeMicrodegrees)
             {
                 return;
             }
 
             HasPendingTarget = true;
-            PendingTargetMicrodegrees = target;
+            PendingTargetMicrodegrees = (int)target;
             PendingSource = "step";
         }
 

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcPositionEstimate.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcPositionEstimate.cs
@@ -1,0 +1,131 @@
+namespace Cubley.Diseqc
+{
+    public sealed class DiseqcPositionEstimate
+    {
+        private const int MicrodegreesPerDegree = 1_000_000;
+        private const int MaximumMagnitudeMicrodegrees =
+            DiseqcLimits.GotoAngularMaxDegrees * MicrodegreesPerDegree;
+
+        public bool HasEstimate { get; private set; }
+
+        public int EstimatedAngleMicrodegrees { get; private set; }
+
+        public string Confidence { get; private set; } = "unknown";
+
+        public string Source { get; private set; } = "none";
+
+        public bool HasPendingTarget { get; private set; }
+
+        public int PendingTargetMicrodegrees { get; private set; }
+
+        public string PendingSource { get; private set; } = "none";
+
+        public int EastStepMicrodegrees { get; private set; }
+
+        public int WestStepMicrodegrees { get; private set; }
+
+        public bool HasStepCalibration
+        {
+            get { return EastStepMicrodegrees > 0 && WestStepMicrodegrees > 0; }
+        }
+
+        public void ConfigureStepCalibration(int eastStepMicrodegrees, int westStepMicrodegrees)
+        {
+            EastStepMicrodegrees = eastStepMicrodegrees;
+            WestStepMicrodegrees = westStepMicrodegrees;
+        }
+
+        public void ClearStepCalibration()
+        {
+            EastStepMicrodegrees = 0;
+            WestStepMicrodegrees = 0;
+            ClearPending();
+        }
+
+        public void BeginGotoAngular(DiseqcMotorDirection direction, int magnitudeMicrodegrees)
+        {
+            ClearPending();
+            if (!IsValidDirection(direction) || magnitudeMicrodegrees < 0 || magnitudeMicrodegrees > MaximumMagnitudeMicrodegrees)
+            {
+                return;
+            }
+
+            HasPendingTarget = true;
+            PendingTargetMicrodegrees = direction == DiseqcMotorDirection.East
+                ? magnitudeMicrodegrees
+                : -magnitudeMicrodegrees;
+            PendingSource = "goto_x";
+        }
+
+        public void BeginStep(DiseqcMotorDirection direction, int steps)
+        {
+            ClearPending();
+            if (!HasEstimate || !HasStepCalibration || !IsValidDirection(direction) || steps < 1 || steps > 128)
+            {
+                return;
+            }
+
+            int stepSize = direction == DiseqcMotorDirection.East
+                ? EastStepMicrodegrees
+                : WestStepMicrodegrees;
+            int signedDelta = direction == DiseqcMotorDirection.East
+                ? stepSize * steps
+                : -(stepSize * steps);
+            int target = EstimatedAngleMicrodegrees + signedDelta;
+            if (target < -MaximumMagnitudeMicrodegrees || target > MaximumMagnitudeMicrodegrees)
+            {
+                return;
+            }
+
+            HasPendingTarget = true;
+            PendingTargetMicrodegrees = target;
+            PendingSource = "step";
+        }
+
+        public bool CompletePending()
+        {
+            if (!HasPendingTarget)
+            {
+                Invalidate();
+                return false;
+            }
+
+            HasEstimate = true;
+            EstimatedAngleMicrodegrees = PendingTargetMicrodegrees;
+            Confidence = "estimated";
+            Source = PendingSource;
+            ClearPending();
+            return true;
+        }
+
+        public void Invalidate()
+        {
+            HasEstimate = false;
+            EstimatedAngleMicrodegrees = 0;
+            Confidence = "unknown";
+            Source = "none";
+            ClearPending();
+        }
+
+        public void FailVerification()
+        {
+            HasEstimate = false;
+            EstimatedAngleMicrodegrees = 0;
+            Confidence = "verification_failed";
+            Source = "none";
+            ClearPending();
+        }
+
+        private static bool IsValidDirection(DiseqcMotorDirection direction)
+        {
+            return direction == DiseqcMotorDirection.East || direction == DiseqcMotorDirection.West;
+        }
+
+        private void ClearPending()
+        {
+            HasPendingTarget = false;
+            PendingTargetMicrodegrees = 0;
+            PendingSource = "none";
+        }
+    }
+}

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcProtocol.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcProtocol.cs
@@ -33,6 +33,12 @@ namespace Cubley.Diseqc
         MiniB = 1,
     }
 
+    public enum DiseqcMotorDirection
+    {
+        East = 0,
+        West = 1,
+    }
+
     public static class DiseqcAddress
     {
         public const byte AnyLnbSwitchSmatv = 0x10;
@@ -48,9 +54,15 @@ namespace Cubley.Diseqc
 
         // 1.2 positioner command set.
         public const byte Halt = 0x60;
+        public const byte LimitsOff = 0x63;
+        public const byte SetEastLimit = 0x66;
+        public const byte SetWestLimit = 0x67;
         public const byte DriveEastOrStep = 0x68;
         public const byte DriveWestOrStep = 0x69;
+        public const byte StorePosition = 0x6A;
         public const byte GotoStoredPosition = 0x6B;
+        public const byte GotoAngularPosition = 0x6E;
+        public const byte RecalculatePositions = 0x6F;
     }
 
     public static class DiseqcLimits
@@ -58,5 +70,6 @@ namespace Cubley.Diseqc
         public const int MinFrameBytes = 3;
         public const int MaxFrameBytes = 6;
         public const int EncodedBitsPerByte = 9;
+        public const int GotoAngularMaxDegrees = 180;
     }
 }

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../CubleyDiseqc.Managed/DiseqcCommandBuilder.cs" Link="Managed/DiseqcCommandBuilder.cs" />
+    <Compile Include="../../CubleyDiseqc.Managed/DiseqcGotoAngleEncoder.cs" Link="Managed/DiseqcGotoAngleEncoder.cs" />
+    <Compile Include="../../CubleyDiseqc.Managed/DiseqcPositionEstimate.cs" Link="Managed/DiseqcPositionEstimate.cs" />
+    <Compile Include="../../CubleyDiseqc.Managed/DiseqcProtocol.cs" Link="Managed/DiseqcProtocol.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcGotoAngleEncoderTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcGotoAngleEncoderTests.cs
@@ -1,0 +1,79 @@
+using Cubley.Diseqc;
+using Xunit;
+
+namespace DiSEqC_Control.Tests;
+
+public sealed class DiseqcGotoAngleEncoderTests
+{
+    [Theory]
+    [InlineData(DiseqcMotorDirection.East, "0", "E0-31-6E-E0-00", 0, "0")]
+    [InlineData(DiseqcMotorDirection.East, "28.2", "E0-31-6E-E1-C3", 282, "28.2")]
+    [InlineData(DiseqcMotorDirection.West, "28.2", "E0-31-6E-D1-C3", 282, "28.2")]
+    [InlineData(DiseqcMotorDirection.East, "36.5625", "E0-31-6E-E2-4A", 366, "36.6")]
+    [InlineData(DiseqcMotorDirection.East, "180", "E0-31-6E-EB-40", 1800, "180")]
+    public void BuildsStandardGotoXVectors(
+        DiseqcMotorDirection direction,
+        string requestedDegrees,
+        string expectedFrame,
+        int expectedTenths,
+        string expectedEncodedDegrees)
+    {
+        bool success = DiseqcGotoAngleEncoder.TryBuildFrame(
+            direction,
+            requestedDegrees,
+            out byte[] frame,
+            out int requestedMicrodegrees,
+            out int encodedTenths,
+            out string error);
+
+        Assert.True(success, error);
+        Assert.Equal(expectedFrame, BitConverter.ToString(frame));
+        Assert.Equal(expectedTenths, encodedTenths);
+        Assert.Equal(expectedEncodedDegrees, DiseqcGotoAngleEncoder.FormatTenths(encodedTenths));
+        Assert.Equal(requestedDegrees, DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees));
+    }
+
+    [Theory]
+    [InlineData("12.34", 123, "12.3")]
+    [InlineData("12.349999", 123, "12.3")]
+    [InlineData("12.35", 124, "12.4")]
+    [InlineData("12.45", 125, "12.5")]
+    public void RoundsToNearestTenthWithHalfUpTies(
+        string requestedDegrees,
+        int expectedTenths,
+        string expectedEncodedDegrees)
+    {
+        bool success = DiseqcGotoAngleEncoder.TryParseDegrees(
+            requestedDegrees,
+            out _,
+            out int encodedTenths,
+            out string error);
+
+        Assert.True(success, error);
+        Assert.Equal(expectedTenths, encodedTenths);
+        Assert.Equal(expectedEncodedDegrees, DiseqcGotoAngleEncoder.FormatTenths(encodedTenths));
+    }
+
+    [Theory]
+    [InlineData(null, "angle_empty")]
+    [InlineData("", "angle_empty")]
+    [InlineData(".5", "angle_format")]
+    [InlineData("5.", "angle_format")]
+    [InlineData("-1", "angle_format")]
+    [InlineData("1.1234567", "angle_precision")]
+    [InlineData("180.000001", "angle_out_of_range")]
+    public void RejectsMalformedAndOutOfRangeAngles(string requestedDegrees, string expectedError)
+    {
+        bool success = DiseqcGotoAngleEncoder.TryBuildFrame(
+            DiseqcMotorDirection.East,
+            requestedDegrees,
+            out byte[] frame,
+            out _,
+            out _,
+            out string error);
+
+        Assert.False(success);
+        Assert.Empty(frame);
+        Assert.Equal(expectedError, error);
+    }
+}

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
@@ -48,6 +48,18 @@ public sealed class DiseqcPositionEstimateTests
         Assert.Equal("verification_failed", estimate.Confidence);
     }
 
+    [Fact]
+    public void StepTargetOutsideRangeDoesNotOverflowIntoPendingTarget()
+    {
+        var estimate = CreateEstimatedPosition(DiseqcMotorDirection.East, 1_000_000);
+        estimate.ConfigureStepCalibration(180_000_000, 180_000_000);
+
+        estimate.BeginStep(DiseqcMotorDirection.East, 128);
+
+        Assert.False(estimate.HasPendingTarget);
+        Assert.Equal(1_000_000, estimate.EstimatedAngleMicrodegrees);
+    }
+
     private static DiseqcPositionEstimate CreateEstimatedPosition(
         DiseqcMotorDirection direction,
         int magnitudeMicrodegrees)

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
@@ -1,0 +1,60 @@
+using Cubley.Diseqc;
+using Xunit;
+
+namespace DiSEqC_Control.Tests;
+
+public sealed class DiseqcPositionEstimateTests
+{
+    [Fact]
+    public void GotoTargetIsAdoptedOnlyAfterCompletion()
+    {
+        var estimate = new DiseqcPositionEstimate();
+
+        estimate.BeginGotoAngular(DiseqcMotorDirection.West, 36_600_000);
+
+        Assert.False(estimate.HasEstimate);
+        Assert.Equal(-36_600_000, estimate.PendingTargetMicrodegrees);
+
+        Assert.True(estimate.CompletePending());
+        Assert.Equal(-36_600_000, estimate.EstimatedAngleMicrodegrees);
+        Assert.Equal("estimated", estimate.Confidence);
+        Assert.Equal("goto_x", estimate.Source);
+    }
+
+    [Fact]
+    public void CalibratedStepsRetainSubTenthDegreePrecision()
+    {
+        var estimate = CreateEstimatedPosition(DiseqcMotorDirection.East, 36_600_000);
+        estimate.ConfigureStepCalibration(25_000, 30_000);
+
+        estimate.BeginStep(DiseqcMotorDirection.West, 30);
+
+        Assert.Equal(35_700_000, estimate.PendingTargetMicrodegrees);
+        Assert.True(estimate.CompletePending());
+        Assert.Equal(35_700_000, estimate.EstimatedAngleMicrodegrees);
+        Assert.Equal("step", estimate.Source);
+    }
+
+    [Fact]
+    public void TimeoutClearsPendingAndCurrentPosition()
+    {
+        var estimate = CreateEstimatedPosition(DiseqcMotorDirection.East, 36_600_000);
+        estimate.BeginGotoAngular(DiseqcMotorDirection.West, 10_000_000);
+
+        estimate.FailVerification();
+
+        Assert.False(estimate.HasEstimate);
+        Assert.False(estimate.HasPendingTarget);
+        Assert.Equal("verification_failed", estimate.Confidence);
+    }
+
+    private static DiseqcPositionEstimate CreateEstimatedPosition(
+        DiseqcMotorDirection direction,
+        int magnitudeMicrodegrees)
+    {
+        var estimate = new DiseqcPositionEstimate();
+        estimate.BeginGotoAngular(direction, magnitudeMicrodegrees);
+        estimate.CompletePending();
+        return estimate;
+    }
+}


### PR DESCRIPTION
## Summary
- encode DiSEqC 1.2 GoToX angles with the canonical tenth-degree fractional lookup
- retain microdegree precision for local position estimates and calibrated steps
- add focused host regression vectors and update the operator/API documentation
- explicitly restore `nanoFramework.System.Text` so clean builds satisfy the deployment manifest merged in #136

## Protocol correction
- `28.2 degrees east` encodes as `E0 31 6E E1 C3`
- `36.5625 degrees east` rounds to `36.6 degrees` and encodes as `E0 31 6E E2 4A`

## Validation
- `dotnet test software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj` (19 passed)
- clean-worktree Debug build from updated `origin/main` (0 errors; 3 existing warnings)
- deployment bundle validation (15 records; 238272 bytes in clean worktree)
- no firmware deployment or flash performed

## Interop
No native interop slots or signatures changed.