### PR TITLE
Persist DiSEqC positioning calibration

### DIFF
--- a/docs/software/CONFIGURATION.md
+++ b/docs/software/CONFIGURATION.md
@@ -5,13 +5,31 @@
 CubleyControl has two persisted configuration domains:
 
 - IPv4, DHCP, and DNS use the standard nanoFramework network configuration block.
-- The device hostname and MQTT settings use the portable 512-byte Cubley
+- The device hostname, MQTT settings, and DiSEqC positioning calibration use the portable 512-byte Cubley
   application record described in
   [CONFIGURATION_STORAGE.md](CONFIGURATION_STORAGE.md).
 
-The active MQTT backend is STM32 internal flash. FRAM is not initialized or
+The active application-configuration backend is STM32 internal flash. FRAM is not initialized or
 probed on the current development board. The application record is deliberately
 backend-neutral so the same bytes can move to dual FRAM slots later.
+
+Persistent positioning values are staged and committed from USB configuration
+mode:
+
+```text
+configure
+diseqc angle-limits 50 50
+diseqc step-calibration 0.112658 0.112658
+diseqc fixed-offset west 3.38
+show candidate-config diseqc
+commit
+exit
+```
+
+Operational `diseqc angle-limits` and `diseqc step-calibration` commands remain
+runtime overrides and do not write flash. `diseqc fixed-offset` is configured
+only through configuration mode. Use `diseqc defaults` or `load defaults diseqc`
+to stage disabled positioning defaults.
 
 ## Application Defaults
 
@@ -106,7 +124,7 @@ backend uses two generation-selected slots to provide atomic record replacement.
 
 ## Credentials
 
-Schema v2 stores MQTT credentials as cleartext in the application record. Password
+Schema v3 stores MQTT credentials as cleartext in the application record. Password
 values are redacted from command debug logs and are never returned by configuration
 commands. TLS and encrypted-at-rest credentials are outside the v1 scope.
 

--- a/docs/software/CONFIGURATION_STORAGE.md
+++ b/docs/software/CONFIGURATION_STORAGE.md
@@ -6,8 +6,8 @@ Define the portable Cubley application configuration record and its physical
 storage backends. The record format is independent of internal flash or FRAM.
 
 Network interface addressing remains in the standard nanoFramework network
-configuration block. The application record stores the device hostname and MQTT
-settings.
+configuration block. The application record stores the device hostname, MQTT
+settings, and DiSEqC positioning calibration.
 
 ## Portable Record
 
@@ -16,7 +16,7 @@ The record is exactly 512 bytes. Integer fields are little-endian.
 | Offset | Size | Field | Description |
 |---:|---:|---|---|
 | `0x000` | 4 | Magic | ASCII `CCFG` |
-| `0x004` | 1 | Schema version | Currently `2` |
+| `0x004` | 1 | Schema version | Currently `3`; version `2` remains readable |
 | `0x005` | 1 | Flags | Reserved, currently `0` |
 | `0x006` | 2 | Payload length | Used bytes from the payload area |
 | `0x008` | 4 | Generation | Monotonic save generation |
@@ -28,7 +28,9 @@ The CRC polynomial is the reflected `0xEDB88320` form with initial value
 
 Schema v2 keys are `hostname`, `enabled`, `broker`, `port`, `client_id`,
 `username`, `password`, `topic_prefix`, `keepalive_seconds`, and
-`reconnect_seconds`. Schema v1 records are not migrated; they are rejected and
+`reconnect_seconds`. Schema v3 adds `de_lim`, `dw_lim`, `de_step`, `dw_step`,
+and `d_offset`, stored as signed or unsigned microdegrees. Missing v3 keys use
+disabled/zero defaults when a v2 record is loaded. Schema v1 records are rejected and
 the application starts with disabled defaults.
 
 ## Active Internal Flash Backend

--- a/docs/software/INTERFACE_COMMAND_MAP_V1.md
+++ b/docs/software/INTERFACE_COMMAND_MAP_V1.md
@@ -129,11 +129,11 @@ CubleyControl console
 |   |   |-- motor-limit <east|west|off>
 |   |   |     Set or disable the motor's internal limits at the current position.
 |   |   |-- angle-limits status|off
-|   |   |     Inspect or disable the volatile angular software limits.
+|   |   |     Inspect or temporarily disable the active angular software limits.
 |   |   |-- angle-limits <east_degrees> <west_degrees>
 |   |   |     Arm direction-specific software limits after checking hardware stops.
 |   |   |-- step-calibration status|off
-|   |   |     Inspect or disable volatile open-loop step calibration.
+|   |   |     Inspect or temporarily disable active open-loop step calibration.
 |   |   |-- step-calibration <east_deg_per_step> <west_deg_per_step>
 |   |   |     Set direction-specific step sizes with up to six decimal places.
 |   |   |-- step <east|west> <1..128>
@@ -401,7 +401,7 @@ The output uses canonical commands only, includes explicit defaults, and has a
 version header. Blank lines and lines beginning with `!` are ignored on input.
 
 ```text
-! cubley-config v2
+! cubley-config v3
 hostname cubley-dish-01
 network mode static
 network address 192.168.1.40
@@ -477,22 +477,30 @@ state. Assignment commands require a value; all reads begin with `show`.
 
 ## Network And MQTT Configuration
 
-Network addressing is persisted by nanoFramework. MQTT settings are written to the
-portable application configuration record. Both are changed only through the USB
+Network addressing is persisted by nanoFramework. MQTT and DiSEqC positioning settings are written to the
+portable application configuration record. All are changed only through the USB
 configuration mode described above.
 
 | Command | Behavior |
 |---|---|
 | `show network` | Show active link, MAC, IPv4, and DNS state. |
 | `show mqtt` | Show active MQTT state, endpoint, reconnect attempts, and last error. |
-| `show running-config [network\|mqtt]` | Show active configuration with passwords redacted. |
-| `show startup-config [network\|mqtt]` | Show persisted configuration with passwords redacted. |
+| `show running-config [network\|mqtt\|diseqc]` | Show active configuration with passwords redacted. |
+| `show startup-config [network\|mqtt\|diseqc]` | Show persisted configuration with passwords redacted. |
 
 Configuration backend and load diagnostics are available separately as
 `show storage` from USB configuration mode.
 
 The public operational grammar does not use `get` or `set`. Network and MQTT
 mutations are accepted only after entering configuration mode.
+
+Configuration mode accepts persistent `diseqc angle-limits <east> <west>`,
+`diseqc step-calibration <east> <west>`, and
+`diseqc fixed-offset <east|west> <degrees>` values. `commit` writes them to the
+portable application record. A fixed offset is added to the signed USALS motor
+angle before direction-specific limit checking and GoToX encoding. For example,
+`fixed-offset west 3.38` changes a requested `36.6` degrees east to an effective
+`33.22` degrees east, encoded as `33.2` degrees.
 
 ## DiSEqC Commands
 
@@ -506,8 +514,8 @@ mutations are accepted only after entering configuration mode.
 | `diseqc motor-limit <east\|west\|off>` | Send motor-internal limit command `0x66`, `0x67`, or `0x63`. East or west records the motor's current physical position as that limit. This does not configure Cubley's angular safety limits. |
 | `diseqc angle-limits <east_degrees> <west_degrees>` | Set positive, direction-specific runtime limits in the protocol range through 180 degrees. Rejected during motion. The operator must choose values strictly inside the motor's physically adjusted hardware stops. |
 | `diseqc angle-limits status` | Show whether angular motion is armed and both direction limits. |
-| `diseqc angle-limits off` | Disable angular movement. This is the power-on default and is rejected during motion. |
-| `diseqc step-calibration <east_deg_per_step> <west_deg_per_step>` | Set volatile direction-specific step sizes with up to six decimal places. Calibration starts disabled after boot. |
+| `diseqc angle-limits off` | Temporarily disable angular movement. Persisted limits are loaded again after reboot. Rejected during motion. |
+| `diseqc step-calibration <east_deg_per_step> <west_deg_per_step>` | Temporarily set direction-specific step sizes with up to six decimal places. Persisted calibration is loaded again after reboot. |
 | `diseqc step-calibration status` | Show step calibration and position-estimate state. |
 | `diseqc step-calibration off` | Disable step calibration. |
 | `diseqc step <east\|west> <steps>` | Move `1..128` steps. |
@@ -549,8 +557,8 @@ exponent notation, and locale decimal separators are rejected because direction
 is a separate argument. The local estimate remains in microdegrees so calibrated
 steps can retain finer resolution than the GoToX command.
 
-Angular software limits are deliberately volatile and start disabled after every
-boot. This fail-closed behavior requires the operator or future station
+Angular software limits start disabled after boot unless persistent values were
+explicitly committed. This fail-closed behavior requires the operator or future station
 orchestrator to confirm the motor's adjustable hardware stops before arming a
 bounded session. A configured software value is not evidence that the physical
 hardware limit was measured correctly.

--- a/docs/software/MQTT_API.md
+++ b/docs/software/MQTT_API.md
@@ -95,7 +95,7 @@ and `state/lnb` to establish or recover current state.
 `position_source`, `pending_target_deg`, `step_calibration_configured`,
 `east_step_deg`, `west_step_deg`, and `timeout_ms`.
 The retained state additionally carries `angle_limits_configured`,
-`east_limit_deg`, and `west_limit_deg`. Successful goto, step, and drive commands
+`east_limit_deg`, `west_limit_deg`, and `goto_offset_deg`. Successful goto, step, and drive commands
 set the state busy. Further movement and raw transmit commands fail as busy until
 Halt, timeout, or `diseqc complete <motion_id>` releases the lock. The ID check
 prevents a stale external completion message from releasing a newer movement.
@@ -103,7 +103,7 @@ prevents a stale external completion message from releasing a newer movement.
 adjustable with `diseqc timeout <5..300>` (seconds, default 90).
 
 Angular movement is fail-closed after boot. Before `diseqc goto-angle` can run,
-set volatile east/west bounds with `diseqc angle-limits <east> <west>` after
+set active east/west bounds with `diseqc angle-limits <east> <west>` after
 confirming that both are inside the motor's adjusted hardware stops. The command
 accepts explicit direction plus unsigned decimal degrees and reports both the
 requested value and the value rounded to the protocol's tenth-degree GoToX
@@ -111,7 +111,7 @@ encoding.
 Transmission records `pending_target_deg` while preserving any prior estimate.
 Matching external completion adopts the encoded GoToX target as
 `position_confidence=estimated`, not `rf_verified`. A step does the same only
-when direction-specific volatile step calibration is configured. Timeout sets
+when direction-specific step calibration is configured. Timeout sets
 `verification_failed`; continuous drive, stored/reference movement, Halt,
 uncalibrated step completion, and raw positioner commands set `unknown`.
 

--- a/software/nanoFramework/CubleyControl/ApplicationConfigurationRecord.cs
+++ b/software/nanoFramework/CubleyControl/ApplicationConfigurationRecord.cs
@@ -6,7 +6,8 @@ namespace CubleyControl
     {
         public const int RecordSize = 512;
         public const int HeaderSize = 16;
-        public const byte SchemaVersion = 2;
+        public const byte SchemaVersion = 3;
+        private const byte LegacySchemaVersion = 2;
 
         public static bool TryEncode(MqttConfiguration configuration, uint generation, out byte[] record, out string error)
         {
@@ -61,7 +62,7 @@ namespace CubleyControl
                 return false;
             }
 
-            if (record[4] != SchemaVersion)
+            if (record[4] != SchemaVersion && record[4] != LegacySchemaVersion)
             {
                 error = "record_version_unsupported";
                 return false;

--- a/software/nanoFramework/CubleyControl/CubleyControl.nfproj
+++ b/software/nanoFramework/CubleyControl/CubleyControl.nfproj
@@ -25,6 +25,7 @@
     <Compile Include="$(BuildInfoSource)" Condition=" '$(BuildInfoSource)' != '' " />
     <Compile Include="Json.cs" />
     <Compile Include="Program.Commands.Configuration.cs" />
+    <Compile Include="Program.Commands.DiseqcConfig.cs" />
     <Compile Include="Program.Commands.Diseqc.cs" />
     <Compile Include="Program.Commands.Lnb.cs" />
     <Compile Include="Program.Commands.Mqtt.cs" />

--- a/software/nanoFramework/CubleyControl/MqttConfiguration.cs
+++ b/software/nanoFramework/CubleyControl/MqttConfiguration.cs
@@ -10,6 +10,7 @@ namespace CubleyControl
         public const int MaximumUsernameLength = 48;
         public const int MaximumPasswordLength = 96;
         public const int MaximumTopicPrefixLength = 64;
+        public const int MaximumDiseqcAngleMicrodegrees = 180_000_000;
 
         public bool Enabled;
         public string Broker = string.Empty;
@@ -21,6 +22,11 @@ namespace CubleyControl
         public string TopicPrefix = "diseqc";
         public int KeepAliveSeconds = 60;
         public int ReconnectSeconds = 5;
+        public int DiseqcEastLimitMicrodegrees;
+        public int DiseqcWestLimitMicrodegrees;
+        public int DiseqcEastStepMicrodegrees;
+        public int DiseqcWestStepMicrodegrees;
+        public int DiseqcGotoOffsetMicrodegrees;
 
         public static MqttConfiguration CreateDefaults()
         {
@@ -40,7 +46,12 @@ namespace CubleyControl
                 Password = Password,
                 TopicPrefix = TopicPrefix,
                 KeepAliveSeconds = KeepAliveSeconds,
-                ReconnectSeconds = ReconnectSeconds
+                ReconnectSeconds = ReconnectSeconds,
+                DiseqcEastLimitMicrodegrees = DiseqcEastLimitMicrodegrees,
+                DiseqcWestLimitMicrodegrees = DiseqcWestLimitMicrodegrees,
+                DiseqcEastStepMicrodegrees = DiseqcEastStepMicrodegrees,
+                DiseqcWestStepMicrodegrees = DiseqcWestStepMicrodegrees,
+                DiseqcGotoOffsetMicrodegrees = DiseqcGotoOffsetMicrodegrees
             };
         }
 
@@ -108,6 +119,25 @@ namespace CubleyControl
                 return false;
             }
 
+            if (!IsValidDiseqcPair(DiseqcEastLimitMicrodegrees, DiseqcWestLimitMicrodegrees))
+            {
+                error = "diseqc_limits_invalid";
+                return false;
+            }
+
+            if (!IsValidDiseqcPair(DiseqcEastStepMicrodegrees, DiseqcWestStepMicrodegrees))
+            {
+                error = "diseqc_steps_invalid";
+                return false;
+            }
+
+            if (DiseqcGotoOffsetMicrodegrees < -MaximumDiseqcAngleMicrodegrees ||
+                DiseqcGotoOffsetMicrodegrees > MaximumDiseqcAngleMicrodegrees)
+            {
+                error = "diseqc_offset_invalid";
+                return false;
+            }
+
             if (ToPayload().Length > ApplicationConfigurationRecord.RecordSize - ApplicationConfigurationRecord.HeaderSize)
             {
                 error = "payload_too_large";
@@ -130,7 +160,12 @@ namespace CubleyControl
                 "password=" + Password + "\n" +
                 "topic_prefix=" + TopicPrefix + "\n" +
                 "keepalive_seconds=" + KeepAliveSeconds.ToString() + "\n" +
-                "reconnect_seconds=" + ReconnectSeconds.ToString();
+                "reconnect_seconds=" + ReconnectSeconds.ToString() + "\n" +
+                "de_lim=" + DiseqcEastLimitMicrodegrees.ToString() + "\n" +
+                "dw_lim=" + DiseqcWestLimitMicrodegrees.ToString() + "\n" +
+                "de_step=" + DiseqcEastStepMicrodegrees.ToString() + "\n" +
+                "dw_step=" + DiseqcWestStepMicrodegrees.ToString() + "\n" +
+                "d_offset=" + DiseqcGotoOffsetMicrodegrees.ToString();
         }
 
         public static bool TryParsePayload(string payload, out MqttConfiguration configuration, out string error)
@@ -221,6 +256,51 @@ namespace CubleyControl
                     }
                     configuration.ReconnectSeconds = number;
                 }
+                else if (key == "de_lim")
+                {
+                    if (!int.TryParse(value, out number))
+                    {
+                        error = "diseqc_east_limit_invalid";
+                        return false;
+                    }
+                    configuration.DiseqcEastLimitMicrodegrees = number;
+                }
+                else if (key == "dw_lim")
+                {
+                    if (!int.TryParse(value, out number))
+                    {
+                        error = "diseqc_west_limit_invalid";
+                        return false;
+                    }
+                    configuration.DiseqcWestLimitMicrodegrees = number;
+                }
+                else if (key == "de_step")
+                {
+                    if (!int.TryParse(value, out number))
+                    {
+                        error = "diseqc_east_step_invalid";
+                        return false;
+                    }
+                    configuration.DiseqcEastStepMicrodegrees = number;
+                }
+                else if (key == "dw_step")
+                {
+                    if (!int.TryParse(value, out number))
+                    {
+                        error = "diseqc_west_step_invalid";
+                        return false;
+                    }
+                    configuration.DiseqcWestStepMicrodegrees = number;
+                }
+                else if (key == "d_offset")
+                {
+                    if (!int.TryParse(value, out number))
+                    {
+                        error = "diseqc_goto_offset_invalid";
+                        return false;
+                    }
+                    configuration.DiseqcGotoOffsetMicrodegrees = number;
+                }
                 else
                 {
                     error = "payload_key_unknown";
@@ -229,6 +309,17 @@ namespace CubleyControl
             }
 
             return configuration.TryValidate(out error);
+        }
+
+        private static bool IsValidDiseqcPair(int eastMicrodegrees, int westMicrodegrees)
+        {
+            if (eastMicrodegrees == 0 && westMicrodegrees == 0)
+            {
+                return true;
+            }
+
+            return eastMicrodegrees > 0 && eastMicrodegrees <= MaximumDiseqcAngleMicrodegrees &&
+                westMicrodegrees > 0 && westMicrodegrees <= MaximumDiseqcAngleMicrodegrees;
         }
 
         private static bool IsValidHostname(string value)

--- a/software/nanoFramework/CubleyControl/Program.Commands.Configuration.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Configuration.cs
@@ -1,3 +1,5 @@
+using Cubley.Diseqc;
+
 namespace CubleyControl
 {
     public static partial class Program
@@ -78,6 +80,12 @@ namespace CubleyControl
                     PrefixConfigurationTokens(tokens, "mqtt"),
                     PrefixConfigurationTokens(valueTokens, "mqtt"),
                     reqId);
+                return;
+            }
+
+            if (head == "diseqc")
+            {
+                HandleSetDiseqcConfigurationCommand(tokens, reqId);
                 return;
             }
 
@@ -195,7 +203,8 @@ namespace CubleyControl
                     "hostname <name|auto>\r\n" +
                     "network <mode dhcp|static|address IP|mask MASK|gateway IP|dns auto|dns static DNS1 [DNS2]|defaults>\r\n" +
                     "mqtt <enabled on|off|broker <HOST|clear>|port PORT|client-id <ID|auto>|username <VALUE|clear>|password <VALUE|clear>|topic-prefix PREFIX|keepalive SEC|reconnect SEC|default|defaults>\r\n" +
-                    "show <running-config|run|startup-config|start|candidate-config|candidate|cand> [network|mqtt]\r\n" +
+                    "diseqc <angle-limits EAST WEST|step-calibration EAST WEST|fixed-offset east|west DEGREES|defaults|off>\r\n" +
+                    "show <running-config|run|startup-config|start|candidate-config|candidate|cand> [network|mqtt|diseqc]\r\n" +
                     "show storage|configuration-storage|config-storage\r\n" +
                     "show diff | show config diff\r\n" +
                     "debug <on|off>\r\n" +
@@ -233,7 +242,14 @@ namespace CubleyControl
             if (topic == "mqtt" || topic == "mq")
             {
                 WriteHumanHeading("MQTT syntax");
-                _activeOutputSink("mqtt <enabled on|off|broker HOST|port PORT|client-id ID|username VALUE|password VALUE|topic-prefix PREFIX|keepalive SEC|reconnect SEC|defaults>\r\n");
+                _activeOutputSink("mqtt <enabled on|off|broker HOST|port PORT|client-id ID|username VALUE|password VALUE|topic-prefix PREFIX|keepalive SEC|reconnect SEC|default|defaults>\r\n");
+                return;
+            }
+
+            if (topic == "diseqc")
+            {
+                WriteHumanHeading("DiSEqC configuration syntax");
+                _activeOutputSink("diseqc <angle-limits EAST WEST|step-calibration EAST WEST|fixed-offset east|west DEGREES|defaults|off>\r\n");
                 return;
             }
 
@@ -241,7 +257,7 @@ namespace CubleyControl
             {
                 WriteHumanHeading("Show syntax");
                 _activeOutputSink(
-                    "show <running-config|run|startup-config|start|candidate-config|candidate|cand> [network|mqtt]\r\n" +
+                    "show <running-config|run|startup-config|start|candidate-config|candidate|cand> [network|mqtt|diseqc]\r\n" +
                     "show storage|configuration-storage|config-storage\r\n" +
                     "show diff | show config diff\r\n");
                 return;
@@ -320,16 +336,32 @@ namespace CubleyControl
 
             if (domain == "mqtt" || domain == "mq" || domain == "all")
             {
+                int eastLimit = _pendingMqttConfiguration.DiseqcEastLimitMicrodegrees;
+                int westLimit = _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees;
+                int eastStep = _pendingMqttConfiguration.DiseqcEastStepMicrodegrees;
+                int westStep = _pendingMqttConfiguration.DiseqcWestStepMicrodegrees;
+                int offset = _pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees;
                 string hostname = _pendingMqttConfiguration.Hostname;
                 _pendingMqttConfiguration = MqttConfiguration.CreateDefaults();
                 if (domain != "all")
                 {
                     _pendingMqttConfiguration.Hostname = hostname;
+                    _pendingMqttConfiguration.DiseqcEastLimitMicrodegrees = eastLimit;
+                    _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees = westLimit;
+                    _pendingMqttConfiguration.DiseqcEastStepMicrodegrees = eastStep;
+                    _pendingMqttConfiguration.DiseqcWestStepMicrodegrees = westStep;
+                    _pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees = offset;
                 }
                 _mqttConfigurationDirty = _pendingMqttConfiguration.ToPayload() != _mqttConfiguration.ToPayload();
             }
 
-            if (domain != "network" && domain != "net" && domain != "mqtt" && domain != "mq" && domain != "all")
+            if (domain == "diseqc")
+            {
+                ClearDiseqcConfiguration(_pendingMqttConfiguration);
+                _mqttConfigurationDirty = _pendingMqttConfiguration.ToPayload() != _mqttConfiguration.ToPayload();
+            }
+
+            if (domain != "network" && domain != "net" && domain != "mqtt" && domain != "mq" && domain != "diseqc" && domain != "all")
             {
                 WriteCommandResult(reqId, false, "validation_error", "defaults domain invalid", "domain=" + domain);
                 return;
@@ -377,7 +409,7 @@ namespace CubleyControl
                     return;
                 }
 
-                if ((domain == "all" || domain == "mqtt") &&
+                if ((domain == "all" || domain == "mqtt" || domain == "diseqc") &&
                     !_applicationConfigurationStorage.TryLoad(out mqtt, out generation, out error))
                 {
                     if (_mqttConfigurationSource == "defaults")
@@ -404,7 +436,7 @@ namespace CubleyControl
 
             if (tokens.Length != index + 1)
             {
-                WriteCommandResult(reqId, false, "validation_error", "configuration display usage", "usage=show <running-config|startup-config|candidate-config> [network|mqtt]");
+                WriteCommandResult(reqId, false, "validation_error", "configuration display usage", "usage=show <running-config|startup-config|candidate-config> [network|mqtt|diseqc]");
                 return null;
             }
 
@@ -419,7 +451,7 @@ namespace CubleyControl
                 return "mqtt";
             }
 
-            if (domain != "network" && domain != "mqtt" && domain != "all")
+            if (domain != "network" && domain != "mqtt" && domain != "diseqc" && domain != "all")
             {
                 WriteCommandResult(reqId, false, "validation_error", "configuration domain invalid", "domain=" + domain);
                 return null;
@@ -439,7 +471,7 @@ namespace CubleyControl
                 return;
             }
 
-            _activeOutputSink("! cubley-config v2 " + source + "\r\n");
+            _activeOutputSink("! cubley-config v3 " + source + "\r\n");
             bool hideDefaults = source == "running";
             NetworkConfiguration defaultNetwork = NetworkConfiguration.CreateDefaults();
             MqttConfiguration defaultMqtt = MqttConfiguration.CreateDefaults();
@@ -475,6 +507,24 @@ namespace CubleyControl
                 EmitConfigurationLine(hideDefaults, mqtt.KeepAliveSeconds != defaultMqtt.KeepAliveSeconds, "mqtt keepalive " + mqtt.KeepAliveSeconds.ToString() + "\r\n");
                 EmitConfigurationLine(hideDefaults, mqtt.ReconnectSeconds != defaultMqtt.ReconnectSeconds, "mqtt reconnect " + mqtt.ReconnectSeconds.ToString() + "\r\n");
             }
+            if (domain == "all" || domain == "diseqc")
+            {
+                EmitConfigurationLine(hideDefaults,
+                    mqtt.DiseqcEastLimitMicrodegrees != 0 || mqtt.DiseqcWestLimitMicrodegrees != 0,
+                    mqtt.DiseqcEastLimitMicrodegrees == 0
+                        ? "diseqc angle-limits off\r\n"
+                        : "diseqc angle-limits " + DiseqcGotoAngleEncoder.FormatMicrodegrees(mqtt.DiseqcEastLimitMicrodegrees) + " " + DiseqcGotoAngleEncoder.FormatMicrodegrees(mqtt.DiseqcWestLimitMicrodegrees) + "\r\n");
+                EmitConfigurationLine(hideDefaults,
+                    mqtt.DiseqcEastStepMicrodegrees != 0 || mqtt.DiseqcWestStepMicrodegrees != 0,
+                    mqtt.DiseqcEastStepMicrodegrees == 0
+                        ? "diseqc step-calibration off\r\n"
+                        : "diseqc step-calibration " + DiseqcGotoAngleEncoder.FormatMicrodegrees(mqtt.DiseqcEastStepMicrodegrees) + " " + DiseqcGotoAngleEncoder.FormatMicrodegrees(mqtt.DiseqcWestStepMicrodegrees) + "\r\n");
+                EmitConfigurationLine(hideDefaults,
+                    mqtt.DiseqcGotoOffsetMicrodegrees != 0,
+                    mqtt.DiseqcGotoOffsetMicrodegrees == 0
+                        ? "diseqc fixed-offset off\r\n"
+                        : "diseqc fixed-offset " + (mqtt.DiseqcGotoOffsetMicrodegrees > 0 ? "east " : "west ") + DiseqcGotoAngleEncoder.FormatMicrodegrees(mqtt.DiseqcGotoOffsetMicrodegrees > 0 ? mqtt.DiseqcGotoOffsetMicrodegrees : -mqtt.DiseqcGotoOffsetMicrodegrees) + "\r\n");
+            }
         }
 
         private static void EmitConfigurationLine(bool hideDefaults, bool differsFromDefault, string line)
@@ -507,6 +557,9 @@ namespace CubleyControl
             changed |= EmitConfigurationDiffLine("mqtt topic-prefix ", _mqttConfiguration.TopicPrefix, _pendingMqttConfiguration.TopicPrefix);
             changed |= EmitConfigurationDiffLine("mqtt keepalive ", _mqttConfiguration.KeepAliveSeconds.ToString(), _pendingMqttConfiguration.KeepAliveSeconds.ToString());
             changed |= EmitConfigurationDiffLine("mqtt reconnect ", _mqttConfiguration.ReconnectSeconds.ToString(), _pendingMqttConfiguration.ReconnectSeconds.ToString());
+            changed |= EmitConfigurationDiffLine("diseqc angle-limits ", FormatDiseqcPair(_mqttConfiguration.DiseqcEastLimitMicrodegrees, _mqttConfiguration.DiseqcWestLimitMicrodegrees), FormatDiseqcPair(_pendingMqttConfiguration.DiseqcEastLimitMicrodegrees, _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees));
+            changed |= EmitConfigurationDiffLine("diseqc step-calibration ", FormatDiseqcPair(_mqttConfiguration.DiseqcEastStepMicrodegrees, _mqttConfiguration.DiseqcWestStepMicrodegrees), FormatDiseqcPair(_pendingMqttConfiguration.DiseqcEastStepMicrodegrees, _pendingMqttConfiguration.DiseqcWestStepMicrodegrees));
+            changed |= EmitConfigurationDiffLine("diseqc fixed-offset ", FormatDiseqcOffset(_mqttConfiguration.DiseqcGotoOffsetMicrodegrees), FormatDiseqcOffset(_pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees));
 
             if (!changed)
             {
@@ -542,6 +595,24 @@ namespace CubleyControl
             return string.IsNullOrEmpty(value) ? "clear" : value;
         }
 
+        private static string FormatDiseqcPair(int eastMicrodegrees, int westMicrodegrees)
+        {
+            return eastMicrodegrees == 0
+                ? "off"
+                : DiseqcGotoAngleEncoder.FormatMicrodegrees(eastMicrodegrees) + " " + DiseqcGotoAngleEncoder.FormatMicrodegrees(westMicrodegrees);
+        }
+
+        private static string FormatDiseqcOffset(int signedMicrodegrees)
+        {
+            if (signedMicrodegrees == 0)
+            {
+                return "off";
+            }
+
+            return (signedMicrodegrees > 0 ? "east " : "west ") +
+                DiseqcGotoAngleEncoder.FormatMicrodegrees(signedMicrodegrees > 0 ? signedMicrodegrees : -signedMicrodegrees);
+        }
+
         private static void CommitCandidateConfiguration(int reqId)
         {
             if (!IsConfigurationDirty())
@@ -571,6 +642,12 @@ namespace CubleyControl
             uint savedMqttGeneration = previousMqttGeneration;
             bool mqttChanged = _mqttConfigurationDirty;
             bool networkChanged = _networkConfigurationDirty;
+
+            if (HasDiseqcConfigurationChanged(candidateMqtt, previousMqtt) && GetActiveDiseqcJobId() != 0)
+            {
+                WriteCommandResult(reqId, false, "busy", "diseqc motion active", "motion_id=" + GetActiveDiseqcJobId().ToString());
+                return;
+            }
 
             if (mqttChanged && !TryPersistMqttConfiguration(candidateMqtt, previousMqttGeneration, out savedMqttGeneration, out error))
             {
@@ -629,6 +706,7 @@ namespace CubleyControl
                 }
                 _mqttConfigurationSource = _applicationConfigurationStorage.Source;
                 _mqttConfigurationError = string.Empty;
+                ApplyDiseqcConfiguration(_mqttConfiguration);
             }
 
             _pendingNetworkConfiguration = _networkConfiguration.Clone();

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -38,6 +38,7 @@ namespace CubleyControl
         private static int _diseqcMotionTimeoutMs = DiseqcMotionWorstCaseMs;
         private static int _diseqcEastTravelLimitMicrodegrees;
         private static int _diseqcWestTravelLimitMicrodegrees;
+        private static int _diseqcGotoOffsetMicrodegrees;
         private static string _diseqcMotionCommandMode = "none";
         private static string _diseqcMotionRequestedAngle = "none";
         private static string _diseqcMotionEncodedAngle = "none";
@@ -239,13 +240,18 @@ namespace CubleyControl
 
                 byte[] frame;
                 int requestedMicrodegrees;
+                DiseqcMotorDirection effectiveDirection;
+                int effectiveMicrodegrees;
                 int encodedAngleTenths;
                 string error;
                 if (!DiseqcCommandBuilder.TryBuildGotoAngularPosition(
                     direction,
                     tokens[3],
+                    _diseqcGotoOffsetMicrodegrees,
                     out frame,
                     out requestedMicrodegrees,
+                    out effectiveDirection,
+                    out effectiveMicrodegrees,
                     out encodedAngleTenths,
                     out error))
                 {
@@ -258,7 +264,7 @@ namespace CubleyControl
                     return;
                 }
 
-                int travelLimit = direction == DiseqcMotorDirection.East
+                int travelLimit = effectiveDirection == DiseqcMotorDirection.East
                     ? _diseqcEastTravelLimitMicrodegrees
                     : _diseqcWestTravelLimitMicrodegrees;
                 if (travelLimit <= 0)
@@ -272,15 +278,16 @@ namespace CubleyControl
                     return;
                 }
 
-                if (!DiseqcGotoAngleEncoder.IsWithinTravelLimit(requestedMicrodegrees, travelLimit))
+                if (!DiseqcGotoAngleEncoder.IsWithinTravelLimit(effectiveMicrodegrees, travelLimit))
                 {
                     WriteCommandResult(
                         reqId,
                         false,
                         "validation_error",
                         "diseqc goto-angle exceeds software limit",
-                        "direction=" + tokens[2] +
+                        "direction=" + (effectiveDirection == DiseqcMotorDirection.East ? "east" : "west") +
                         " requested_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees) +
+                        " effective_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(effectiveMicrodegrees) +
                         " limit_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(travelLimit));
                     return;
                 }
@@ -289,12 +296,12 @@ namespace CubleyControl
                     reqId,
                     "diseqc goto-angle",
                     frame,
-                    "goto_angle_" + tokens[2],
+                    "goto_angle_" + (effectiveDirection == DiseqcMotorDirection.East ? "east" : "west"),
                     _diseqcMotionTimeoutMs,
                     "angular",
                     DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees),
                     DiseqcGotoAngleEncoder.FormatTenths(encodedAngleTenths),
-                    tokens[2],
+                    effectiveDirection == DiseqcMotorDirection.East ? "east" : "west",
                     encodedAngleTenths * 100_000);
                 return;
             }
@@ -562,6 +569,7 @@ namespace CubleyControl
                 WriteHumanField("West step calibration", westStep == "Disabled" ? westStep : westStep + " deg");
                 WriteHumanField("East software limit", FormatDiseqcTravelLimit(_diseqcEastTravelLimitMicrodegrees));
                 WriteHumanField("West software limit", FormatDiseqcTravelLimit(_diseqcWestTravelLimitMicrodegrees));
+                WriteHumanField("GoToX fixed offset", FormatSignedDiseqcAngle(_diseqcGotoOffsetMicrodegrees) + " deg");
                 WriteHumanField("Watchdog timeout", (_diseqcMotionTimeoutMs / 1000).ToString() + " s");
                 return;
             }
@@ -651,7 +659,8 @@ namespace CubleyControl
             return "angle_limits_configured=" +
                 (_diseqcEastTravelLimitMicrodegrees > 0 && _diseqcWestTravelLimitMicrodegrees > 0 ? "1" : "0") +
                 " east_limit_deg=" + FormatDiseqcTravelLimit(_diseqcEastTravelLimitMicrodegrees) +
-                " west_limit_deg=" + FormatDiseqcTravelLimit(_diseqcWestTravelLimitMicrodegrees);
+                " west_limit_deg=" + FormatDiseqcTravelLimit(_diseqcWestTravelLimitMicrodegrees) +
+                " goto_offset_deg=" + FormatSignedDiseqcAngle(_diseqcGotoOffsetMicrodegrees);
         }
 
         private static string FormatDiseqcTravelLimit(int microdegrees)

--- a/software/nanoFramework/CubleyControl/Program.Commands.DiseqcConfig.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.DiseqcConfig.cs
@@ -1,0 +1,180 @@
+using Cubley.Diseqc;
+
+namespace CubleyControl
+{
+    public static partial class Program
+    {
+        private static void HandleSetDiseqcConfigurationCommand(string[] tokens, int reqId)
+        {
+            if (tokens.Length < 2)
+            {
+                WriteDiseqcConfigurationUsage(reqId);
+                return;
+            }
+
+            MqttConfiguration previous = _pendingMqttConfiguration.Clone();
+            string field = tokens[1];
+            if (field == "angle-limits")
+            {
+                if (tokens.Length == 3 && tokens[2] == "off")
+                {
+                    _pendingMqttConfiguration.DiseqcEastLimitMicrodegrees = 0;
+                    _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees = 0;
+                    StageDiseqcConfigurationChange(reqId, field, "off", previous);
+                    return;
+                }
+
+                int eastMicrodegrees;
+                int eastTenths;
+                int westMicrodegrees;
+                int westTenths;
+                string error;
+                if (tokens.Length != 4 ||
+                    !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[2], out eastMicrodegrees, out eastTenths, out error) ||
+                    !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[3], out westMicrodegrees, out westTenths, out error) ||
+                    eastMicrodegrees == 0 || westMicrodegrees == 0)
+                {
+                    WriteDiseqcConfigurationUsage(reqId);
+                    return;
+                }
+
+                _pendingMqttConfiguration.DiseqcEastLimitMicrodegrees = eastMicrodegrees;
+                _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees = westMicrodegrees;
+                StageDiseqcConfigurationChange(reqId, field, tokens[2] + "," + tokens[3], previous);
+                return;
+            }
+
+            if (field == "step-calibration")
+            {
+                if (tokens.Length == 3 && tokens[2] == "off")
+                {
+                    _pendingMqttConfiguration.DiseqcEastStepMicrodegrees = 0;
+                    _pendingMqttConfiguration.DiseqcWestStepMicrodegrees = 0;
+                    StageDiseqcConfigurationChange(reqId, field, "off", previous);
+                    return;
+                }
+
+                int eastMicrodegrees;
+                int eastTenths;
+                int westMicrodegrees;
+                int westTenths;
+                string error;
+                if (tokens.Length != 4 ||
+                    !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[2], out eastMicrodegrees, out eastTenths, out error) ||
+                    !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[3], out westMicrodegrees, out westTenths, out error) ||
+                    eastMicrodegrees == 0 || westMicrodegrees == 0)
+                {
+                    WriteDiseqcConfigurationUsage(reqId);
+                    return;
+                }
+
+                _pendingMqttConfiguration.DiseqcEastStepMicrodegrees = eastMicrodegrees;
+                _pendingMqttConfiguration.DiseqcWestStepMicrodegrees = westMicrodegrees;
+                StageDiseqcConfigurationChange(reqId, field, tokens[2] + "," + tokens[3], previous);
+                return;
+            }
+
+            if (field == "fixed-offset")
+            {
+                if (tokens.Length == 3 && tokens[2] == "off")
+                {
+                    _pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees = 0;
+                    StageDiseqcConfigurationChange(reqId, field, "off", previous);
+                    return;
+                }
+
+                int magnitudeMicrodegrees;
+                int magnitudeTenths;
+                string error;
+                if (tokens.Length != 4 ||
+                    (tokens[2] != "east" && tokens[2] != "west") ||
+                    !DiseqcGotoAngleEncoder.TryParseDegrees(tokens[3], out magnitudeMicrodegrees, out magnitudeTenths, out error))
+                {
+                    WriteDiseqcConfigurationUsage(reqId);
+                    return;
+                }
+
+                _pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees = tokens[2] == "east"
+                    ? magnitudeMicrodegrees
+                    : -magnitudeMicrodegrees;
+                StageDiseqcConfigurationChange(reqId, field, tokens[2] + "," + tokens[3], previous);
+                return;
+            }
+
+            if (field == "defaults" && tokens.Length == 2)
+            {
+                ClearDiseqcConfiguration(_pendingMqttConfiguration);
+                StageDiseqcConfigurationChange(reqId, field, "disabled", previous);
+                return;
+            }
+
+            WriteDiseqcConfigurationUsage(reqId);
+        }
+
+        private static void StageDiseqcConfigurationChange(
+            int reqId,
+            string field,
+            string value,
+            MqttConfiguration previous)
+        {
+            string error;
+            if (!_pendingMqttConfiguration.TryValidate(out error))
+            {
+                _pendingMqttConfiguration = previous;
+                WriteCommandResult(reqId, false, "validation_error", "diseqc configuration invalid", "field=" + field + " reason=" + error);
+                return;
+            }
+
+            _mqttConfigurationDirty = _pendingMqttConfiguration.ToPayload() != _mqttConfiguration.ToPayload();
+            WriteCommandResult(reqId, true, "ok", "configuration staged", "field=diseqc_" + field + " value=" + value + " state=" + (_mqttConfigurationDirty ? "staged" : "saved"));
+        }
+
+        private static void ApplyDiseqcConfiguration(MqttConfiguration configuration)
+        {
+            lock (_diseqcMotionLock)
+            {
+                _diseqcEastTravelLimitMicrodegrees = configuration.DiseqcEastLimitMicrodegrees;
+                _diseqcWestTravelLimitMicrodegrees = configuration.DiseqcWestLimitMicrodegrees;
+                _diseqcGotoOffsetMicrodegrees = configuration.DiseqcGotoOffsetMicrodegrees;
+                if (configuration.DiseqcEastStepMicrodegrees > 0 && configuration.DiseqcWestStepMicrodegrees > 0)
+                {
+                    _diseqcPositionEstimate.ConfigureStepCalibration(
+                        configuration.DiseqcEastStepMicrodegrees,
+                        configuration.DiseqcWestStepMicrodegrees);
+                }
+                else
+                {
+                    _diseqcPositionEstimate.ClearStepCalibration();
+                }
+            }
+        }
+
+        private static bool HasDiseqcConfigurationChanged(MqttConfiguration first, MqttConfiguration second)
+        {
+            return first.DiseqcEastLimitMicrodegrees != second.DiseqcEastLimitMicrodegrees ||
+                first.DiseqcWestLimitMicrodegrees != second.DiseqcWestLimitMicrodegrees ||
+                first.DiseqcEastStepMicrodegrees != second.DiseqcEastStepMicrodegrees ||
+                first.DiseqcWestStepMicrodegrees != second.DiseqcWestStepMicrodegrees ||
+                first.DiseqcGotoOffsetMicrodegrees != second.DiseqcGotoOffsetMicrodegrees;
+        }
+
+        private static void ClearDiseqcConfiguration(MqttConfiguration configuration)
+        {
+            configuration.DiseqcEastLimitMicrodegrees = 0;
+            configuration.DiseqcWestLimitMicrodegrees = 0;
+            configuration.DiseqcEastStepMicrodegrees = 0;
+            configuration.DiseqcWestStepMicrodegrees = 0;
+            configuration.DiseqcGotoOffsetMicrodegrees = 0;
+        }
+
+        private static void WriteDiseqcConfigurationUsage(int reqId)
+        {
+            WriteCommandResult(
+                reqId,
+                false,
+                "validation_error",
+                "diseqc configuration usage",
+                "usage=diseqc <angle-limits EAST WEST|step-calibration EAST WEST|fixed-offset east|west DEGREES|defaults|off>");
+        }
+    }
+}

--- a/software/nanoFramework/CubleyControl/Program.Commands.MqttConfig.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.MqttConfig.cs
@@ -56,8 +56,18 @@ namespace CubleyControl
             if ((field == "default" || field == "defaults") && tokens.Length == 3)
             {
                 string hostname = _pendingMqttConfiguration.Hostname;
+                int eastLimit = _pendingMqttConfiguration.DiseqcEastLimitMicrodegrees;
+                int westLimit = _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees;
+                int eastStep = _pendingMqttConfiguration.DiseqcEastStepMicrodegrees;
+                int westStep = _pendingMqttConfiguration.DiseqcWestStepMicrodegrees;
+                int offset = _pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees;
                 _pendingMqttConfiguration = MqttConfiguration.CreateDefaults();
                 _pendingMqttConfiguration.Hostname = hostname;
+                _pendingMqttConfiguration.DiseqcEastLimitMicrodegrees = eastLimit;
+                _pendingMqttConfiguration.DiseqcWestLimitMicrodegrees = westLimit;
+                _pendingMqttConfiguration.DiseqcEastStepMicrodegrees = eastStep;
+                _pendingMqttConfiguration.DiseqcWestStepMicrodegrees = westStep;
+                _pendingMqttConfiguration.DiseqcGotoOffsetMicrodegrees = offset;
                 StageApplicationChange(reqId, "mqtt-defaults", "disabled", previous);
                 return;
             }
@@ -166,7 +176,7 @@ namespace CubleyControl
 
         private static void WriteMqttSetUsage(int reqId)
         {
-            WriteCommandResult(reqId, false, "validation_error", "mqtt usage", "usage=mqtt <enabled on|off|broker HOST|port PORT|client-id ID|username VALUE|password VALUE|topic-prefix PREFIX|keepalive SEC|reconnect SEC|defaults>");
+            WriteCommandResult(reqId, false, "validation_error", "mqtt usage", "usage=mqtt <enabled on|off|broker HOST|port PORT|client-id ID|username VALUE|password VALUE|topic-prefix PREFIX|keepalive SEC|reconnect SEC|default|defaults>");
         }
     }
 }

--- a/software/nanoFramework/CubleyControl/Program.MqttConfiguration.cs
+++ b/software/nanoFramework/CubleyControl/Program.MqttConfiguration.cs
@@ -36,6 +36,7 @@ namespace CubleyControl
             _pendingMqttConfiguration = _mqttConfiguration.Clone();
             _mqttConfigurationDirty = false;
             _mqttConfigurationRevision = 1;
+            ApplyDiseqcConfiguration(_mqttConfiguration);
             WriteStructuredDebug(
                 "CONFIG",
                 "schema=1 sub=config comp=storage domain=mqtt operation=load" +

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcCommandBuilder.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcCommandBuilder.cs
@@ -103,6 +103,29 @@ namespace Cubley.Diseqc
                 out error);
         }
 
+        public static bool TryBuildGotoAngularPosition(
+            DiseqcMotorDirection direction,
+            string degrees,
+            int signedOffsetMicrodegrees,
+            out byte[] frame,
+            out int requestedMicrodegrees,
+            out DiseqcMotorDirection effectiveDirection,
+            out int effectiveMicrodegrees,
+            out int encodedAngleTenths,
+            out string error)
+        {
+            return DiseqcGotoAngleEncoder.TryBuildFrame(
+                direction,
+                degrees,
+                signedOffsetMicrodegrees,
+                out frame,
+                out requestedMicrodegrees,
+                out effectiveDirection,
+                out effectiveMicrodegrees,
+                out encodedAngleTenths,
+                out error);
+        }
+
         public static byte[] BuildWritePortGroupN0(byte option)
         {
             return BuildFrame(DiseqcFraming.FirstTransmissionNoReply, DiseqcAddress.AnyLnbSwitchSmatv, DiseqcCommand.WriteN0, option);

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcGotoAngleEncoder.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcGotoAngleEncoder.cs
@@ -18,8 +18,35 @@ namespace Cubley.Diseqc
             out int encodedAngleTenths,
             out string error)
         {
+            DiseqcMotorDirection effectiveDirection;
+            int effectiveMicrodegrees;
+            return TryBuildFrame(
+                direction,
+                degrees,
+                0,
+                out frame,
+                out requestedMicrodegrees,
+                out effectiveDirection,
+                out effectiveMicrodegrees,
+                out encodedAngleTenths,
+                out error);
+        }
+
+        public static bool TryBuildFrame(
+            DiseqcMotorDirection direction,
+            string degrees,
+            int signedOffsetMicrodegrees,
+            out byte[] frame,
+            out int requestedMicrodegrees,
+            out DiseqcMotorDirection effectiveDirection,
+            out int effectiveMicrodegrees,
+            out int encodedAngleTenths,
+            out string error)
+        {
             frame = new byte[0];
             requestedMicrodegrees = 0;
+            effectiveDirection = DiseqcMotorDirection.East;
+            effectiveMicrodegrees = 0;
             encodedAngleTenths = 0;
             error = string.Empty;
 
@@ -29,12 +56,34 @@ namespace Cubley.Diseqc
                 return false;
             }
 
-            if (!TryParseDegrees(degrees, out requestedMicrodegrees, out encodedAngleTenths, out error))
+            int ignoredTenths;
+            if (!TryParseDegrees(degrees, out requestedMicrodegrees, out ignoredTenths, out error))
             {
                 return false;
             }
 
-            int directionWord = direction == DiseqcMotorDirection.East ? 0xE000 : 0xD000;
+            long signedRequestedMicrodegrees = direction == DiseqcMotorDirection.East
+                ? requestedMicrodegrees
+                : -((long)requestedMicrodegrees);
+            long signedEffectiveMicrodegrees = signedRequestedMicrodegrees + signedOffsetMicrodegrees;
+            long maximumMicrodegrees = (long)DiseqcLimits.GotoAngularMaxDegrees * MicrodegreesPerDegree;
+            if (signedEffectiveMicrodegrees < -maximumMicrodegrees || signedEffectiveMicrodegrees > maximumMicrodegrees)
+            {
+                error = "offset_out_of_range";
+                return false;
+            }
+
+            effectiveDirection = signedEffectiveMicrodegrees < 0
+                ? DiseqcMotorDirection.West
+                : DiseqcMotorDirection.East;
+            effectiveMicrodegrees = (int)(signedEffectiveMicrodegrees < 0
+                ? -signedEffectiveMicrodegrees
+                : signedEffectiveMicrodegrees);
+            long scaled = ((long)effectiveMicrodegrees * TenthsPerDegree) +
+                (MicrodegreesPerDegree / 2);
+            encodedAngleTenths = (int)(scaled / MicrodegreesPerDegree);
+
+            int directionWord = effectiveDirection == DiseqcMotorDirection.East ? 0xE000 : 0xD000;
             int wholeDegrees = encodedAngleTenths / TenthsPerDegree;
             int fractionalTenth = encodedAngleTenths % TenthsPerDegree;
             int positionWord = directionWord | (wholeDegrees << 4) | FractionCodeByTenth[fractionalTenth];

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/ApplicationConfigurationRecordTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/ApplicationConfigurationRecordTests.cs
@@ -1,0 +1,60 @@
+using CubleyControl;
+using Xunit;
+
+namespace DiSEqC_Control.Tests;
+
+public sealed class ApplicationConfigurationRecordTests
+{
+    [Fact]
+    public void RoundTripPreservesDiseqcPositioningConfiguration()
+    {
+        MqttConfiguration expected = MqttConfiguration.CreateDefaults();
+        expected.DiseqcEastLimitMicrodegrees = 50_000_000;
+        expected.DiseqcWestLimitMicrodegrees = 45_000_000;
+        expected.DiseqcEastStepMicrodegrees = 112_658;
+        expected.DiseqcWestStepMicrodegrees = 112_658;
+        expected.DiseqcGotoOffsetMicrodegrees = -3_380_000;
+
+        Assert.True(ApplicationConfigurationRecord.TryEncode(expected, 7, out byte[] record, out string encodeError), encodeError);
+        Assert.Equal(ApplicationConfigurationRecord.SchemaVersion, record[4]);
+        Assert.True(ApplicationConfigurationRecord.TryDecode(record, out MqttConfiguration actual, out uint generation, out string decodeError), decodeError);
+
+        Assert.Equal((uint)7, generation);
+        Assert.Equal(expected.ToPayload(), actual.ToPayload());
+    }
+
+    [Fact]
+    public void LegacyPayloadLoadsPositioningDefaults()
+    {
+        const string legacyPayload =
+            "enabled=false\n" +
+            "broker=\n" +
+            "port=1883\n" +
+            "client_id=\n" +
+            "hostname=cubley-test\n" +
+            "username=\n" +
+            "password=\n" +
+            "topic_prefix=diseqc\n" +
+            "keepalive_seconds=60\n" +
+            "reconnect_seconds=5";
+
+        Assert.True(MqttConfiguration.TryParsePayload(legacyPayload, out MqttConfiguration actual, out string decodeError), decodeError);
+        Assert.Equal("cubley-test", actual.Hostname);
+        Assert.Equal(0, actual.DiseqcEastLimitMicrodegrees);
+        Assert.Equal(0, actual.DiseqcWestLimitMicrodegrees);
+        Assert.Equal(0, actual.DiseqcEastStepMicrodegrees);
+        Assert.Equal(0, actual.DiseqcWestStepMicrodegrees);
+        Assert.Equal(0, actual.DiseqcGotoOffsetMicrodegrees);
+    }
+
+    [Fact]
+    public void SchemaTwoRecordHeaderRemainsReadable()
+    {
+        MqttConfiguration expected = MqttConfiguration.CreateDefaults();
+        Assert.True(ApplicationConfigurationRecord.TryEncode(expected, 3, out byte[] record, out string encodeError), encodeError);
+        record[4] = 2;
+
+        Assert.True(ApplicationConfigurationRecord.TryDecode(record, out _, out uint generation, out string decodeError), decodeError);
+        Assert.Equal((uint)3, generation);
+    }
+}

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj
@@ -12,6 +12,8 @@
     <Compile Include="../../CubleyDiseqc.Managed/DiseqcGotoAngleEncoder.cs" Link="Managed/DiseqcGotoAngleEncoder.cs" />
     <Compile Include="../../CubleyDiseqc.Managed/DiseqcPositionEstimate.cs" Link="Managed/DiseqcPositionEstimate.cs" />
     <Compile Include="../../CubleyDiseqc.Managed/DiseqcProtocol.cs" Link="Managed/DiseqcProtocol.cs" />
+    <Compile Include="../../CubleyControl/ApplicationConfigurationRecord.cs" Link="Control/ApplicationConfigurationRecord.cs" />
+    <Compile Include="../../CubleyControl/MqttConfiguration.cs" Link="Control/MqttConfiguration.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcGotoAngleEncoderTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcGotoAngleEncoderTests.cs
@@ -76,4 +76,52 @@ public sealed class DiseqcGotoAngleEncoderTests
         Assert.Empty(frame);
         Assert.Equal(expectedError, error);
     }
+
+    [Theory]
+    [InlineData(DiseqcMotorDirection.East, "36.6", -3_380_000, DiseqcMotorDirection.East, 33_220_000, "E0-31-6E-E2-13")]
+    [InlineData(DiseqcMotorDirection.East, "2", -3_400_000, DiseqcMotorDirection.West, 1_400_000, "E0-31-6E-D0-16")]
+    [InlineData(DiseqcMotorDirection.West, "2", 3_400_000, DiseqcMotorDirection.East, 1_400_000, "E0-31-6E-E0-16")]
+    public void AppliesSignedOffsetBeforeEncoding(
+        DiseqcMotorDirection requestedDirection,
+        string requestedDegrees,
+        int signedOffsetMicrodegrees,
+        DiseqcMotorDirection expectedDirection,
+        int expectedEffectiveMicrodegrees,
+        string expectedFrame)
+    {
+        bool success = DiseqcGotoAngleEncoder.TryBuildFrame(
+            requestedDirection,
+            requestedDegrees,
+            signedOffsetMicrodegrees,
+            out byte[] frame,
+            out _,
+            out DiseqcMotorDirection effectiveDirection,
+            out int effectiveMicrodegrees,
+            out _,
+            out string error);
+
+        Assert.True(success, error);
+        Assert.Equal(expectedDirection, effectiveDirection);
+        Assert.Equal(expectedEffectiveMicrodegrees, effectiveMicrodegrees);
+        Assert.Equal(expectedFrame, BitConverter.ToString(frame));
+    }
+
+    [Fact]
+    public void RejectsOffsetTargetOutsideMotorRange()
+    {
+        bool success = DiseqcGotoAngleEncoder.TryBuildFrame(
+            DiseqcMotorDirection.East,
+            "179",
+            2_000_000,
+            out byte[] frame,
+            out _,
+            out _,
+            out _,
+            out _,
+            out string error);
+
+        Assert.False(success);
+        Assert.Empty(frame);
+        Assert.Equal("offset_out_of_range", error);
+    }
 }


### PR DESCRIPTION
## Summary
- persist east/west angle limits, directional step calibration, and signed fixed GoToX offset in the application configuration record
- add staged configuration commands, startup application, defaults, diff/show output, and motion-safe commit handling
- write schema v3 while retaining schema-v2 record compatibility and preserving DiSEqC fields during MQTT-only resets
- apply fixed offset before GoToX direction selection and effective software-limit checks

## Validation
- `dotnet test software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj --no-restore` (27 passed)
- `./toolchain/build-CubleyControl.sh build --project CubleyControl/CubleyControl.nfproj --configuration Debug` (passed; 15 records, 243,832 bytes)
- `git diff --check`

No firmware deployment or board movement was performed.