### PR TITLE
Add REST GoToX positioner operation

### DIFF
--- a/docs/software/DEVICE_API_V2.md
+++ b/docs/software/DEVICE_API_V2.md
@@ -160,10 +160,10 @@ intrinsic duration, and the fallback for `goto` and `step`.
 ### Lifecycle
 
 ```
-positioner.goto/step/drive ──> running ──┬── positioner.halt ────> halted
-                                         ├── watchdog expiry ────> timeout
-                                         │                         timeout_halt_failed
-                                         └── positioner.release ─> released
+positioner.goto/goto_angle/step/drive ──> running ──┬── positioner.halt ────> halted
+                                                    ├── watchdog expiry ────> timeout
+                                                    │                         timeout_halt_failed
+                                                    └── positioner.release ─> released
 ```
 
 Only one job runs at a time. A motion command while a job is `running` fails
@@ -185,14 +185,24 @@ with `busy` and names the active job; it does not queue. The device retains the
 
 | `op` | Parameters | Response |
 |---|---|---|
-| `positioner.goto` | `position` int 0–255 | `accepted` + `job`, or `busy` |
+| `positioner.goto` | `position` int 0–60 | `accepted` + `job`, or `busy` |
+| `positioner.goto_angle` | `direction` `"east"`\|`"west"`, `angle` decimal string from `"0"` through `"180"` with up to six fractional digits | `accepted` + `job`, or `busy` |
 | `positioner.step` | `direction` `"east"`\|`"west"`, `count` int 1–128 | `accepted` + `job`, or `busy` |
 | `positioner.drive` | `direction` `"east"`\|`"west"` | `accepted` + `job`, or `busy` |
 | `positioner.halt` | — | `ok`; terminates the active job as `halted` |
 | `positioner.release` | `job` int | `ok`; terminates that job as `released` |
 
 `positioner.release` checks the job id, so a late release for a superseded job
-is rejected rather than ending a newer movement.
+is rejected rather than ending a newer movement. Releasing a GoToX job promotes
+its offset-adjusted, protocol-rounded pending target to
+`position_confidence=estimated`. Releasing a calibrated step job similarly
+promotes its pending target. Stored-position, uncalibrated-step, and continuous
+drive jobs leave the angular estimate unknown.
+
+`angle` is a string because inbound JSON deliberately rejects floating-point
+numbers. The operation applies the persisted signed GoToX offset, enforces the
+configured direction-specific angular limit, and uses the same DiSEqC rounding
+and motion-lock path as console `diseqc goto-angle`.
 
 ### Bridged operations
 

--- a/docs/software/DEVICE_API_V2_DEVELOPER_GUIDE.md
+++ b/docs/software/DEVICE_API_V2_DEVELOPER_GUIDE.md
@@ -1,0 +1,202 @@
+# Cubley Device REST API v2 Developer Guide
+
+Status: **draft and subject to change**. The API is implemented but has not yet
+been fully exercised on hardware. The canonical contract is
+[DEVICE_API_V2.md](DEVICE_API_V2.md).
+
+## Transport
+
+- Base URL: `http://<device-ip>`
+- Endpoint: `POST /api/v2/commands`
+- Content type: `application/json`
+- No authentication or TLS; use only on a trusted network.
+- HTTP status-code mappings are not yet contractual. Clients should parse the
+  JSON response envelope.
+
+## Request Envelope
+
+```json
+{
+  "v": 2,
+  "id": "unique-request-id",
+  "op": "positioner.goto",
+  "position": 12
+}
+```
+
+- `v`: Contract version; currently `2`.
+- `id`: Required idempotency key, 1-32 characters matching `A-Za-z0-9._:-`.
+- `op`: Required operation name.
+- Remaining fields depend on the operation.
+
+Generate a new `id` for each logical command. Retrying the exact same payload
+with the same ID within 120 seconds does not execute it twice.
+
+## Payload Restrictions
+
+Requests must:
+
+- Be one JSON object, no larger than 256 ASCII bytes.
+- Contain at most 12 members.
+- Use keys no longer than 24 characters.
+- Use string values no longer than 128 characters.
+- Contain only strings, integers, booleans, or `null`.
+- Not contain arrays, nested objects, floating-point, or exponent numbers.
+- Not contain unknown members.
+
+Raw DiSEqC frames use uppercase hex strings, for example `"E01038F0"`.
+
+## Operations
+
+| Operation | Parameters |
+|---|---|
+| `positioner.goto` | `position`: integer 0-60; position 0 is the motor reference |
+| `positioner.goto_angle` | `direction`: `"east"` or `"west"`; `angle`: decimal string from `"0"` through `"180"`, with up to six fractional digits |
+| `positioner.step` | `direction`: `"east"` or `"west"`; `count`: integer 1-128 |
+| `positioner.drive` | `direction`: `"east"` or `"west"` |
+| `positioner.halt` | None |
+| `positioner.release` | `job`: integer |
+| `lnb.enable` | `channel` |
+| `lnb.disable` | `channel` |
+| `lnb.polarization` | `channel`, `value` |
+| `lnb.band` | `channel`, `value` |
+| `diseqc.tx` | `frame`: uppercase hex, 1-6 bytes |
+| `diseqc.preset` | `value` |
+| `diseqc.tone` | `value`: `"on"` or `"off"` |
+
+The accepted values for bridged LNB fields are not fully frozen in the draft.
+Coordinate with the firmware team before depending on them.
+
+Configuration operations are available only through the USB console, not REST.
+
+## Response Envelope
+
+```json
+{
+  "v": 2,
+  "id": "unique-request-id",
+  "ok": true,
+  "code": "accepted",
+  "job": 7,
+  "ts_ms": 41231
+}
+```
+
+Always present:
+
+- `v`: Contract version.
+- `id`: Request ID, or `"?"` if parsing failed.
+- `ok`: Whether the command was accepted or completed.
+- `code`: Machine-readable result.
+- `ts_ms`: Device uptime, not wall-clock time.
+
+Optional:
+
+- `msg`: Failure detail.
+- `job`: Started or blocking positioner job.
+- `data`: Structured result.
+- `lines`: Newline-separated output from legacy bridged operations.
+- `replayed`: The response came from the idempotency cache.
+
+Result codes are `ok`, `accepted`, `validation_error`, `unsupported`, `busy`,
+`hw_fault`, `id_conflict`, and `not_found`.
+
+## Positioner Jobs
+
+Motion operations return `accepted` with a job ID and continue asynchronously.
+Only one motion job may run at a time; another motion request returns `busy`.
+
+Job states:
+
+- `running`
+- `halted`
+- `timeout`
+- `timeout_halt_failed`
+- `released`
+
+There is no `succeeded` state because DiSEqC does not report arrival. A
+controller should detect completion externally, such as through signal lock,
+then call:
+
+```json
+{
+  "v": 2,
+  "id": "release-7",
+  "op": "positioner.release",
+  "job": 7
+}
+```
+
+Releasing a `positioner.goto_angle` job promotes its offset-adjusted and
+protocol-rounded pending target to `position_confidence=estimated`. Releasing a
+calibrated step job promotes that pending target in the same way. This remains
+an open-loop estimate: release is the controller's assertion that movement
+finished, not feedback from the motor.
+
+A watchdog eventually halts unreleased motion.
+
+## MQTT Notifications
+
+REST is used for commands and immediate responses. MQTT is used for asynchronous
+announcements under `<prefix>/<hostname>`.
+
+Relevant topics:
+
+- `event/diseqc`: Non-retained job transitions.
+- `state/diseqc`: Retained current and recent job state.
+- `availability`: Retained `online` or `offline` state.
+
+Use state messages to recover after reconnecting and event messages for live
+transitions. See [MQTT_API.md](MQTT_API.md) for transport details.
+
+## Example
+
+```bash
+curl -X POST "http://<device-ip>/api/v2/commands" \
+  -H "Content-Type: application/json" \
+  --data '{"v":2,"id":"goto-12-001","op":"positioner.goto","position":12}'
+```
+
+## Calibrated GoToX Sequence
+
+The following sequence enables LNB output A, references the motor, and then
+moves to the Cheltenham Astra 2 GoToX angle. It requires `jq`, persisted GoToX
+offset and angular limits, and a fresh request ID for every logical command.
+Only release each job after observing that the motor has physically stopped.
+
+```bash
+BASE_URL="http://<device-ip>/api/v2/commands"
+run_id="cal-$(date +%s)"
+
+curl -fsS "$BASE_URL" \
+  -H 'Content-Type: application/json' \
+  --data "{\"v\":2,\"id\":\"$run_id-lnb\",\"op\":\"lnb.enable\",\"channel\":\"a\"}"
+
+reference_response=$(curl -fsS "$BASE_URL" \
+  -H 'Content-Type: application/json' \
+  --data "{\"v\":2,\"id\":\"$run_id-ref\",\"op\":\"positioner.goto\",\"position\":0}")
+printf '%s\n' "$reference_response" | jq .
+reference_job=$(printf '%s\n' "$reference_response" |
+  jq -er 'select(.ok and .code == "accepted") | .job')
+
+# Wait for the motor to stop at reference before releasing this job.
+curl -fsS "$BASE_URL" \
+  -H 'Content-Type: application/json' \
+  --data "{\"v\":2,\"id\":\"$run_id-ref-release\",\"op\":\"positioner.release\",\"job\":$reference_job}"
+
+goto_response=$(curl -fsS "$BASE_URL" \
+  -H 'Content-Type: application/json' \
+  --data "{\"v\":2,\"id\":\"$run_id-astra2\",\"op\":\"positioner.goto_angle\",\"direction\":\"east\",\"angle\":\"36.6\"}")
+printf '%s\n' "$goto_response" | jq .
+goto_job=$(printf '%s\n' "$goto_response" |
+  jq -er 'select(.ok and .code == "accepted") | .job')
+
+# Wait for physical cessation and verify the known Astra 2 signal first.
+curl -fsS "$BASE_URL" \
+  -H 'Content-Type: application/json' \
+  --data "{\"v\":2,\"id\":\"$run_id-astra2-release\",\"op\":\"positioner.release\",\"job\":$goto_job}"
+```
+
+Do not release a job if arrival is uncertain. Use `positioner.halt` instead; a
+Halt or watchdog timeout deliberately prevents the pending target from becoming
+an estimated position.

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -238,71 +238,7 @@ namespace CubleyControl
                     return;
                 }
 
-                byte[] frame;
-                int requestedMicrodegrees;
-                DiseqcMotorDirection effectiveDirection;
-                int effectiveMicrodegrees;
-                int encodedAngleTenths;
-                string error;
-                if (!DiseqcCommandBuilder.TryBuildGotoAngularPosition(
-                    direction,
-                    tokens[3],
-                    _diseqcGotoOffsetMicrodegrees,
-                    out frame,
-                    out requestedMicrodegrees,
-                    out effectiveDirection,
-                    out effectiveMicrodegrees,
-                    out encodedAngleTenths,
-                    out error))
-                {
-                    WriteCommandResult(
-                        reqId,
-                        false,
-                        "validation_error",
-                        "diseqc goto-angle invalid",
-                        "angle=" + SanitizeToken(tokens[3]) + " reason=" + SanitizeToken(error));
-                    return;
-                }
-
-                int travelLimit = effectiveDirection == DiseqcMotorDirection.East
-                    ? _diseqcEastTravelLimitMicrodegrees
-                    : _diseqcWestTravelLimitMicrodegrees;
-                if (travelLimit <= 0)
-                {
-                    WriteCommandResult(
-                        reqId,
-                        false,
-                        "validation_error",
-                        "diseqc angle limits not configured",
-                        "usage=diseqc angle-limits <east_degrees> <west_degrees>");
-                    return;
-                }
-
-                if (!DiseqcGotoAngleEncoder.IsWithinTravelLimit(effectiveMicrodegrees, travelLimit))
-                {
-                    WriteCommandResult(
-                        reqId,
-                        false,
-                        "validation_error",
-                        "diseqc goto-angle exceeds software limit",
-                        "direction=" + (effectiveDirection == DiseqcMotorDirection.East ? "east" : "west") +
-                        " requested_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees) +
-                        " effective_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(effectiveMicrodegrees) +
-                        " limit_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(travelLimit));
-                    return;
-                }
-
-                EmitDiseqcPositionerTransmitResult(
-                    reqId,
-                    "diseqc goto-angle",
-                    frame,
-                    "goto_angle_" + (effectiveDirection == DiseqcMotorDirection.East ? "east" : "west"),
-                    _diseqcMotionTimeoutMs,
-                    "angular",
-                    DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees),
-                    DiseqcGotoAngleEncoder.FormatTenths(encodedAngleTenths),
-                    effectiveDirection == DiseqcMotorDirection.East ? "east" : "west",
-                    encodedAngleTenths * 100_000);
+                RunDiseqcGotoAngle(reqId, direction, tokens[3]);
                 return;
             }
 
@@ -504,6 +440,89 @@ namespace CubleyControl
             }
 
             WriteCommandResult(reqId, false, "unsupported", "unknown positioner operation", "operation=" + operation.ToString());
+        }
+
+        private static void RunPositionerGotoAngle(DiseqcMotorDirection direction, string degrees)
+        {
+            int reqId = NextRequestId();
+            _activeCommandIsSetter = true;
+            _activeCommand = "positioner goto-angle";
+
+            if (!EnsureDiseqcMotionIdle(reqId))
+            {
+                return;
+            }
+
+            RunDiseqcGotoAngle(reqId, direction, degrees);
+        }
+
+        private static void RunDiseqcGotoAngle(int reqId, DiseqcMotorDirection direction, string degrees)
+        {
+            byte[] frame;
+            int requestedMicrodegrees;
+            DiseqcMotorDirection effectiveDirection;
+            int effectiveMicrodegrees;
+            int encodedAngleTenths;
+            string error;
+            if (!DiseqcCommandBuilder.TryBuildGotoAngularPosition(
+                direction,
+                degrees,
+                _diseqcGotoOffsetMicrodegrees,
+                out frame,
+                out requestedMicrodegrees,
+                out effectiveDirection,
+                out effectiveMicrodegrees,
+                out encodedAngleTenths,
+                out error))
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc goto-angle invalid",
+                    "angle=" + SanitizeToken(degrees) + " reason=" + SanitizeToken(error));
+                return;
+            }
+
+            int travelLimit = effectiveDirection == DiseqcMotorDirection.East
+                ? _diseqcEastTravelLimitMicrodegrees
+                : _diseqcWestTravelLimitMicrodegrees;
+            if (travelLimit <= 0)
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc angle limits not configured",
+                    "usage=diseqc angle-limits <east_degrees> <west_degrees>");
+                return;
+            }
+
+            if (!DiseqcGotoAngleEncoder.IsWithinTravelLimit(effectiveMicrodegrees, travelLimit))
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "validation_error",
+                    "diseqc goto-angle exceeds software limit",
+                    "direction=" + (effectiveDirection == DiseqcMotorDirection.East ? "east" : "west") +
+                    " requested_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees) +
+                    " effective_angle_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(effectiveMicrodegrees) +
+                    " limit_deg=" + DiseqcGotoAngleEncoder.FormatMicrodegrees(travelLimit));
+                return;
+            }
+
+            EmitDiseqcPositionerTransmitResult(
+                reqId,
+                "diseqc goto-angle",
+                frame,
+                "goto_angle_" + (effectiveDirection == DiseqcMotorDirection.East ? "east" : "west"),
+                _diseqcMotionTimeoutMs,
+                "angular",
+                DiseqcGotoAngleEncoder.FormatMicrodegrees(requestedMicrodegrees),
+                DiseqcGotoAngleEncoder.FormatTenths(encodedAngleTenths),
+                effectiveDirection == DiseqcMotorDirection.East ? "east" : "west",
+                encodedAngleTenths * 100_000);
         }
 
         private static void EmitDiseqcShowSummaryLine()

--- a/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
@@ -320,6 +320,11 @@ namespace CubleyControl
 
         private static string ExecuteMqttOperation(string commandId, string op, JsonObject command)
         {
+            if (op == "positioner.goto_angle")
+            {
+                return ExecuteMqttPositionerGotoAngle(commandId, command);
+            }
+
             if (op == "positioner.goto" || op == "positioner.step" ||
                 op == "positioner.drive" || op == "positioner.halt")
             {
@@ -437,6 +442,54 @@ namespace CubleyControl
                 null);
         }
 
+        private static string ExecuteMqttPositionerGotoAngle(string commandId, JsonObject command)
+        {
+            string error;
+            if (!TryValidateMqttMembers(command, "direction", "angle", out error))
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", error, 0);
+            }
+
+            string direction;
+            if (!command.TryGetString("direction", out direction) ||
+                (direction != "east" && direction != "west"))
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", "direction must be \"east\" or \"west\"", 0);
+            }
+
+            string angle;
+            if (!command.TryGetString("angle", out angle))
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", "angle must be a decimal string", 0);
+            }
+
+            ResetMqttCommandOutcome();
+            ExecutePositionerGotoAngle(
+                direction == "east" ? DiseqcMotorDirection.East : DiseqcMotorDirection.West,
+                angle,
+                MqttOutputSink);
+
+            if (!_mqttResultOk)
+            {
+                return BuildMqttFailureBody(
+                    commandId,
+                    _mqttResultCode.Length == 0 ? "hw_fault" : _mqttResultCode,
+                    _mqttResultMsg,
+                    _blockingDiseqcJobId);
+            }
+
+            int jobId = _lastStartedDiseqcJobId;
+            bool started = jobId != 0 && GetActiveDiseqcJobId() == jobId;
+            return BuildMqttResponseBody(
+                commandId,
+                true,
+                started ? "accepted" : "ok",
+                null,
+                started ? null : BuildDiseqcStateJson(),
+                jobId,
+                null);
+        }
+
         private static string ExecuteMqttPositionerQuery(string commandId, string op, JsonObject command)
         {
             string error;
@@ -457,6 +510,11 @@ namespace CubleyControl
             if (!TryEndDiseqcJob(jobId, JobStateReleased, string.Empty))
             {
                 return BuildMqttFailureBody(commandId, "validation_error", "job is not the running job", GetActiveDiseqcJobId());
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                _diseqcPositionEstimate.CompletePending();
             }
 
             PublishMqttDiseqcJobTransition("end", jobId);

--- a/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
+++ b/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
@@ -143,9 +143,22 @@ namespace CubleyControl
                         {
                             RunPositionerOperation(operation, value);
                         }
-                        else
+                        else if (mode == CommandModePositionerGotoAngle)
                         {
                             RunPositionerGotoAngle(direction, degrees);
+                        }
+                        else
+                        {
+                            WriteStructuredDebug(
+                                "COMMAND",
+                                "schema=1 sub=command comp=dispatch operation=reject stat=error" +
+                                " reason=unknown_mode mode=" + mode.ToString());
+                            WriteCommandResult(
+                                NextRequestId(),
+                                false,
+                                "unsupported",
+                                "unknown command mode",
+                                "mode=" + mode.ToString());
                         }
                     }
                 }

--- a/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
+++ b/software/nanoFramework/CubleyControl/Program.Infrastructure.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Device.Gpio;
 using System.Threading;
+using Cubley.Diseqc;
 using Cubley.Interop;
 
 namespace CubleyControl
@@ -82,10 +83,11 @@ namespace CubleyControl
 
         private const int CommandModeConsoleText = 0;
         private const int CommandModePositioner = 1;
+        private const int CommandModePositionerGotoAngle = 2;
 
         private static void ExecuteCommand(string command, OutputSink outputSink, CommandTransport transport)
         {
-            ExecuteCommandCore(CommandModeConsoleText, command, 0, 0, outputSink, transport);
+            ExecuteCommandCore(CommandModeConsoleText, command, 0, 0, null, DiseqcMotorDirection.East, outputSink, transport);
         }
 
         /// <summary>
@@ -95,7 +97,23 @@ namespace CubleyControl
         /// </summary>
         private static void ExecutePositionerOperation(int operation, int value, OutputSink outputSink)
         {
-            ExecuteCommandCore(CommandModePositioner, null, operation, value, outputSink, CommandTransport.Rest);
+            ExecuteCommandCore(CommandModePositioner, null, operation, value, null, DiseqcMotorDirection.East, outputSink, CommandTransport.Rest);
+        }
+
+        private static void ExecutePositionerGotoAngle(
+            DiseqcMotorDirection direction,
+            string degrees,
+            OutputSink outputSink)
+        {
+            ExecuteCommandCore(
+                CommandModePositionerGotoAngle,
+                null,
+                0,
+                0,
+                degrees,
+                direction,
+                outputSink,
+                CommandTransport.Rest);
         }
 
         private static void ExecuteCommandCore(
@@ -103,6 +121,8 @@ namespace CubleyControl
             string command,
             int operation,
             int value,
+            string degrees,
+            DiseqcMotorDirection direction,
             OutputSink outputSink,
             CommandTransport transport)
         {
@@ -119,9 +139,13 @@ namespace CubleyControl
                         {
                             HandleConsoleCommand(command);
                         }
-                        else
+                        else if (mode == CommandModePositioner)
                         {
                             RunPositionerOperation(operation, value);
+                        }
+                        else
+                        {
+                            RunPositionerGotoAngle(direction, degrees);
                         }
                     }
                 }

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
@@ -22,6 +22,35 @@ public sealed class DiseqcPositionEstimateTests
     }
 
     [Fact]
+    public void RestGotoAngleAdoptsOffsetAdjustedEncodedTargetOnRelease()
+    {
+        bool success = DiseqcCommandBuilder.TryBuildGotoAngularPosition(
+            DiseqcMotorDirection.East,
+            "36.6",
+            -3_380_000,
+            out _,
+            out int requestedMicrodegrees,
+            out DiseqcMotorDirection effectiveDirection,
+            out _,
+            out int encodedAngleTenths,
+            out string error);
+        var estimate = new DiseqcPositionEstimate();
+
+        Assert.True(success, error);
+        Assert.Equal(36_600_000, requestedMicrodegrees);
+        Assert.Equal(DiseqcMotorDirection.East, effectiveDirection);
+
+        estimate.BeginGotoAngular(effectiveDirection, encodedAngleTenths * 100_000);
+
+        Assert.False(estimate.HasEstimate);
+        Assert.Equal(33_200_000, estimate.PendingTargetMicrodegrees);
+        Assert.True(estimate.CompletePending());
+        Assert.Equal(33_200_000, estimate.EstimatedAngleMicrodegrees);
+        Assert.Equal("estimated", estimate.Confidence);
+        Assert.Equal("goto_x", estimate.Source);
+    }
+
+    [Fact]
     public void CalibratedStepsRetainSubTenthDegreePrecision()
     {
         var estimate = CreateEstimatedPosition(DiseqcMotorDirection.East, 36_600_000);


### PR DESCRIPTION
## Summary
- add structured `positioner.goto_angle` REST operation using decimal-string angles
- reuse CLI offset, rounding, angular-limit, motion-lock, and estimate handling
- promote pending GoToX and calibrated-step targets when REST jobs are released
- document the v2 contract and calibrated curl workflow

## Validation
- `dotnet test software/nanoFramework/tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj --no-restore` (28 passed)
- `./toolchain/build-CubleyControl.sh build --project CubleyControl/CubleyControl.nfproj --configuration Debug`
- interop guard and checksum validation passed
- documented Bash examples pass `bash -n`

## Hardware
- not deployed or exercised on target hardware