### PR TITLE
Add REST state probing and positioner job completion

### DIFF
--- a/docs/software/DEVICE_API_V2.md
+++ b/docs/software/DEVICE_API_V2.md
@@ -39,6 +39,13 @@ Send commands with `POST /api/v2/commands` over HTTP. The request and response
 content type is `application/json`. A command result is returned in the HTTP
 response body; the device does not publish command responses to MQTT.
 
+Read current device state with:
+
+- `GET /api/v2/health`
+- `GET /api/v2/state/positioner`
+- `GET /api/v2/state/lnb`
+- `GET /api/v2/jobs/{job}`
+
 MQTT 3.1.1 remains the announcement transport. Its topic root is
 `<prefix>/<hostname>`; see [MQTT_API.md](MQTT_API.md) for topics and delivery
 semantics. The device does not subscribe to any MQTT topic.
@@ -104,12 +111,13 @@ UUID is ideal, and 32 chars is enough for either).
 Exactly one response object is returned per HTTP request.
 
 ```json
-{"v":2,"id":"01J8ZK4M7Q","ok":true,"code":"accepted","job":7,"ts_ms":41231}
+{"v":2,"boot_id":"d942c94f-16fd-4d8e-b6d5-44201d3caa4c","id":"01J8ZK4M7Q","ok":true,"code":"accepted","job":7,"ts_ms":41231}
 ```
 
 | Member | Type | Always | Meaning |
 |---|---|---|---|
 | `v` | int | yes | Always `2`. |
+| `boot_id` | string | yes | Changes on every boot. Job IDs are meaningful only within this boot. |
 | `id` | string | yes | Echo of the command `id`, or `"?"` if the envelope was unparseable. |
 | `ok` | bool | yes | Whether the command was accepted and completed. |
 | `code` | string | yes | Machine-readable outcome, see below. |
@@ -145,14 +153,14 @@ that represents "the dish is moving".
 | `halted` | yes | `positioner.halt` stopped it, or a `stop` was issued at the console. |
 | `timeout` | yes | The motion watchdog expired and the device transmitted Halt. |
 | `timeout_halt_failed` | yes | The watchdog expired but the Halt transmission failed. **The positioner may still be moving.** |
-| `released` | yes | A client asserted that motion finished. |
+| `completed` | yes | A client asserted that motion finished and supplied a verification result. |
 
 **There is deliberately no `succeeded` state.** A DiSEqC 1.2 positioner returns
 no arrival indication, so the device cannot know the dish reached its target —
-it only knows what it transmitted and how much time has passed. `released`
-records a *client's claim* of arrival, not a device observation. Any consumer
-that needs true arrival must establish it out of band (signal lock, for
-example) and then call `positioner.release`.
+it only knows what it transmitted and how much time has passed. `completed`
+records a client's result, not motor feedback from the device. A consumer can
+report RF verification obtained out of band when it calls
+`positioner.complete`.
 
 `timeout` is the normal terminal state for `positioner.drive`, which has no
 intrinsic duration, and the fallback for `goto` and `step`.
@@ -163,7 +171,7 @@ intrinsic duration, and the fallback for `goto` and `step`.
 positioner.goto/goto_angle/step/drive ──> running ──┬── positioner.halt ────> halted
                                                     ├── watchdog expiry ────> timeout
                                                     │                         timeout_halt_failed
-                                                    └── positioner.release ─> released
+                                                    └── positioner.complete ─> completed
 ```
 
 Only one job runs at a time. A motion command while a job is `running` fails
@@ -173,11 +181,15 @@ with `busy` and names the active job; it does not queue. The device retains the
 ### Job object
 
 ```json
-{"job":7,"op":"goto","state":"running","remaining_ms":83400,"timeout_ms":90000,"detail":""}
+{"job":7,"op":"goto","state":"running","verification":"pending","remaining_ms":83400,"timeout_ms":90000,"detail":""}
 ```
 
 `remaining_ms` is 0 for terminal states. `detail` carries a failure reason for
 `timeout_halt_failed` and is empty otherwise.
+
+`verification` is `pending` while running, `estimated`, `rf_verified`, or
+`verification_failed` after client completion, and `none` for other terminal
+paths.
 
 ## Operations
 
@@ -190,14 +202,36 @@ with `busy` and names the active job; it does not queue. The device retains the
 | `positioner.step` | `direction` `"east"`\|`"west"`, `count` int 1–128 | `accepted` + `job`, or `busy` |
 | `positioner.drive` | `direction` `"east"`\|`"west"` | `accepted` + `job`, or `busy` |
 | `positioner.halt` | — | `ok`; terminates the active job as `halted` |
-| `positioner.release` | `job` int | `ok`; terminates that job as `released` |
+| `positioner.complete` | `job` int, `verification` string | `ok`; terminates that job as `completed` |
 
-`positioner.release` checks the job id, so a late release for a superseded job
-is rejected rather than ending a newer movement. Releasing a GoToX job promotes
-its offset-adjusted, protocol-rounded pending target to
-`position_confidence=estimated`. Releasing a calibrated step job similarly
-promotes its pending target. Stored-position, uncalibrated-step, and continuous
-drive jobs leave the angular estimate unknown.
+`positioner.complete` checks the job id, so a late completion for a superseded
+job is rejected rather than ending a newer movement. `verification` accepts:
+
+- `estimated`: adopt a GoToX or calibrated-step pending target with estimated
+  confidence.
+- `rf_verified`: adopt that pending target with RF-verified confidence. The
+  command is rejected if the job has no angular pending target.
+- `verification_failed`: invalidate the position estimate.
+
+The device always adopts its offset-adjusted, protocol-rounded pending target;
+the client cannot inject an arbitrary angle. Stored-position, uncalibrated-step,
+and continuous-drive jobs cannot be marked `rf_verified`.
+
+### REST queries
+
+Read-only responses use this envelope and do not require a request ID:
+
+```json
+{"v":2,"boot_id":"d942c94f-16fd-4d8e-b6d5-44201d3caa4c","ok":true,"code":"ok","ts_ms":41500,"data":{}}
+```
+
+`GET /api/v2/jobs/{job}` returns a retained job object. The device retains the
+four most recent jobs; an unknown or evicted ID returns HTTP 404 with
+`code=not_found`. `GET /api/v2/state/positioner` returns the active and most
+recent terminal jobs plus the current position confidence, estimated angle,
+source, and pending target. `GET /api/v2/state/lnb` returns the current LNB
+health, communication, fault, register, polarization, and band snapshot.
+`GET /api/v2/health` returns liveness and the firmware version.
 
 `angle` is a string because inbound JSON deliberately rejects floating-point
 numbers. The operation applies the persisted signed GoToX offset, enforces the

--- a/docs/software/DEVICE_API_V2_DEVELOPER_GUIDE.md
+++ b/docs/software/DEVICE_API_V2_DEVELOPER_GUIDE.md
@@ -8,6 +8,8 @@ been fully exercised on hardware. The canonical contract is
 
 - Base URL: `http://<device-ip>`
 - Endpoint: `POST /api/v2/commands`
+- Read endpoints: `/api/v2/health`, `/api/v2/state/positioner`,
+  `/api/v2/state/lnb`, and `/api/v2/jobs/{job}`
 - Content type: `application/json`
 - No authentication or TLS; use only on a trusted network.
 - HTTP status-code mappings are not yet contractual. Clients should parse the
@@ -55,7 +57,7 @@ Raw DiSEqC frames use uppercase hex strings, for example `"E01038F0"`.
 | `positioner.step` | `direction`: `"east"` or `"west"`; `count`: integer 1-128 |
 | `positioner.drive` | `direction`: `"east"` or `"west"` |
 | `positioner.halt` | None |
-| `positioner.release` | `job`: integer |
+| `positioner.complete` | `job`: integer; `verification`: `estimated`, `rf_verified`, or `verification_failed` |
 | `lnb.enable` | `channel` |
 | `lnb.disable` | `channel` |
 | `lnb.polarization` | `channel`, `value` |
@@ -74,6 +76,7 @@ Configuration operations are available only through the USB console, not REST.
 ```json
 {
   "v": 2,
+  "boot_id": "d942c94f-16fd-4d8e-b6d5-44201d3caa4c",
   "id": "unique-request-id",
   "ok": true,
   "code": "accepted",
@@ -85,6 +88,7 @@ Configuration operations are available only through the USB console, not REST.
 Always present:
 
 - `v`: Contract version.
+- `boot_id`: Per-boot identity; treat job IDs from another boot as stale.
 - `id`: Request ID, or `"?"` if parsing failed.
 - `ok`: Whether the command was accepted or completed.
 - `code`: Machine-readable result.
@@ -112,7 +116,7 @@ Job states:
 - `halted`
 - `timeout`
 - `timeout_halt_failed`
-- `released`
+- `completed`
 
 There is no `succeeded` state because DiSEqC does not report arrival. A
 controller should detect completion externally, such as through signal lock,
@@ -121,19 +125,32 @@ then call:
 ```json
 {
   "v": 2,
-  "id": "release-7",
-  "op": "positioner.release",
-  "job": 7
+  "id": "complete-7",
+  "op": "positioner.complete",
+  "job": 7,
+  "verification": "rf_verified"
 }
 ```
 
-Releasing a `positioner.goto_angle` job promotes its offset-adjusted and
-protocol-rounded pending target to `position_confidence=estimated`. Releasing a
-calibrated step job promotes that pending target in the same way. This remains
-an open-loop estimate: release is the controller's assertion that movement
-finished, not feedback from the motor.
+`rf_verified` promotes the device's offset-adjusted and protocol-rounded pending
+target to `position_confidence=rf_verified`; the client does not supply an
+angle. Use `estimated` when motion stopped without independent verification, or
+`verification_failed` when RF evidence disproves arrival. Stored-position,
+uncalibrated-step, and continuous-drive jobs have no angular pending target and
+cannot be marked `rf_verified`.
 
-A watchdog eventually halts unreleased motion.
+A watchdog eventually halts incomplete motion.
+
+## State Queries
+
+All read responses include `v`, `boot_id`, `ok`, `code`, `ts_ms`, and `data`.
+Poll `GET /api/v2/jobs/{job}` after a motion command. A missing or evicted job
+returns HTTP 404 and `code=not_found`. Use `GET /api/v2/state/positioner` to
+recover the active job and position confidence after reconnecting, and
+`GET /api/v2/state/lnb` for current LNB health and fault state.
+
+`GET /api/v2/health` is the lightweight liveness endpoint. A changed `boot_id`
+means cached job IDs and uptime values belong to an earlier boot.
 
 ## MQTT Notifications
 
@@ -182,7 +199,7 @@ reference_job=$(printf '%s\n' "$reference_response" |
 # Wait for the motor to stop at reference before releasing this job.
 curl -fsS "$BASE_URL" \
   -H 'Content-Type: application/json' \
-  --data "{\"v\":2,\"id\":\"$run_id-ref-release\",\"op\":\"positioner.release\",\"job\":$reference_job}"
+  --data "{\"v\":2,\"id\":\"$run_id-ref-complete\",\"op\":\"positioner.complete\",\"job\":$reference_job,\"verification\":\"estimated\"}"
 
 goto_response=$(curl -fsS "$BASE_URL" \
   -H 'Content-Type: application/json' \
@@ -194,9 +211,9 @@ goto_job=$(printf '%s\n' "$goto_response" |
 # Wait for physical cessation and verify the known Astra 2 signal first.
 curl -fsS "$BASE_URL" \
   -H 'Content-Type: application/json' \
-  --data "{\"v\":2,\"id\":\"$run_id-astra2-release\",\"op\":\"positioner.release\",\"job\":$goto_job}"
+  --data "{\"v\":2,\"id\":\"$run_id-astra2-complete\",\"op\":\"positioner.complete\",\"job\":$goto_job,\"verification\":\"rf_verified\"}"
 ```
 
-Do not release a job if arrival is uncertain. Use `positioner.halt` instead; a
+Do not complete a job if arrival is uncertain. Use `positioner.halt` instead; a
 Halt or watchdog timeout deliberately prevents the pending target from becoming
 an estimated position.

--- a/docs/software/DEVICE_API_V2_DEVELOPER_GUIDE.md
+++ b/docs/software/DEVICE_API_V2_DEVELOPER_GUIDE.md
@@ -179,7 +179,7 @@ curl -X POST "http://<device-ip>/api/v2/commands" \
 The following sequence enables LNB output A, references the motor, and then
 moves to the Cheltenham Astra 2 GoToX angle. It requires `jq`, persisted GoToX
 offset and angular limits, and a fresh request ID for every logical command.
-Only release each job after observing that the motor has physically stopped.
+Only complete each job after observing that the motor has physically stopped.
 
 ```bash
 BASE_URL="http://<device-ip>/api/v2/commands"
@@ -196,7 +196,7 @@ printf '%s\n' "$reference_response" | jq .
 reference_job=$(printf '%s\n' "$reference_response" |
   jq -er 'select(.ok and .code == "accepted") | .job')
 
-# Wait for the motor to stop at reference before releasing this job.
+# Wait for the motor to stop at reference before completing this job.
 curl -fsS "$BASE_URL" \
   -H 'Content-Type: application/json' \
   --data "{\"v\":2,\"id\":\"$run_id-ref-complete\",\"op\":\"positioner.complete\",\"job\":$reference_job,\"verification\":\"estimated\"}"

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -1140,10 +1140,11 @@ namespace CubleyControl
 
             string operation;
             string state;
+            string verification;
             int remainingMs;
             int timeoutMs;
             string detail;
-            TryGetDiseqcJobSnapshot(motionId, out operation, out state, out remainingMs, out timeoutMs, out detail);
+            TryGetDiseqcJobSnapshot(motionId, out operation, out state, out verification, out remainingMs, out timeoutMs, out detail);
             _blockingDiseqcJobId = motionId;
 
             WriteCommandResult(
@@ -1174,7 +1175,7 @@ namespace CubleyControl
             }
 
             if (activeJobId != requestedMotionId ||
-                !TryEndDiseqcJob(requestedMotionId, JobStateReleased, string.Empty))
+                !TryEndDiseqcJob(requestedMotionId, JobStateCompleted, "estimated", string.Empty))
             {
                 WriteCommandResult(reqId, false, "validation_error", "diseqc motion id mismatch", "motion_id=" + activeJobId.ToString());
                 return;

--- a/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Mqtt.cs
@@ -331,9 +331,9 @@ namespace CubleyControl
                 return ExecuteMqttPositionerMotion(commandId, op, command);
             }
 
-            if (op == "positioner.release")
+            if (op == "positioner.complete")
             {
-                return ExecuteMqttPositionerQuery(commandId, op, command);
+                return ExecuteMqttPositionerComplete(commandId, command);
             }
 
             return ExecuteMqttBridgedOperation(commandId, op, command);
@@ -490,11 +490,11 @@ namespace CubleyControl
                 null);
         }
 
-        private static string ExecuteMqttPositionerQuery(string commandId, string op, JsonObject command)
+        private static string ExecuteMqttPositionerComplete(string commandId, JsonObject command)
         {
             string error;
 
-            if (!TryValidateMqttMembers(command, "job", null, out error))
+            if (!TryValidateMqttMembers(command, "job", "verification", out error))
             {
                 return BuildMqttFailureBody(commandId, "validation_error", error, 0);
             }
@@ -505,16 +505,59 @@ namespace CubleyControl
                 return BuildMqttFailureBody(commandId, "validation_error", "job must be a positive integer", 0);
             }
 
-            // positioner.release: the identity check inside TryEndDiseqcJob is
-            // what stops a late release from ending a newer movement.
-            if (!TryEndDiseqcJob(jobId, JobStateReleased, string.Empty))
+            string verification;
+            if (!command.TryGetString("verification", out verification) ||
+                (verification != "estimated" && verification != "rf_verified" &&
+                verification != "verification_failed"))
+            {
+                return BuildMqttFailureBody(
+                    commandId,
+                    "validation_error",
+                    "verification must be estimated, rf_verified, or verification_failed",
+                    0);
+            }
+
+            if (BuildDiseqcJobJson(jobId) == "null")
+            {
+                return BuildMqttFailureBody(commandId, "not_found", "job is unknown or has been evicted", 0);
+            }
+
+            if (GetActiveDiseqcJobId() != jobId)
             {
                 return BuildMqttFailureBody(commandId, "validation_error", "job is not the running job", GetActiveDiseqcJobId());
             }
 
             lock (_diseqcMotionLock)
             {
-                _diseqcPositionEstimate.CompletePending();
+                if (verification == "rf_verified" && !_diseqcPositionEstimate.HasPendingTarget)
+                {
+                    return BuildMqttFailureBody(
+                        commandId,
+                        "validation_error",
+                        "job has no angular target to verify",
+                        jobId);
+                }
+            }
+
+            if (!TryEndDiseqcJob(jobId, JobStateCompleted, verification, string.Empty))
+            {
+                return BuildMqttFailureBody(commandId, "validation_error", "job is not the running job", GetActiveDiseqcJobId());
+            }
+
+            lock (_diseqcMotionLock)
+            {
+                if (verification == "rf_verified")
+                {
+                    _diseqcPositionEstimate.CompletePendingAsRfVerified();
+                }
+                else if (verification == "verification_failed")
+                {
+                    _diseqcPositionEstimate.FailVerification();
+                }
+                else
+                {
+                    _diseqcPositionEstimate.CompletePending();
+                }
             }
 
             PublishMqttDiseqcJobTransition("end", jobId);
@@ -835,6 +878,7 @@ namespace CubleyControl
         {
             JsonBuilder builder = new JsonBuilder()
                 .AddInt("v", DeviceContractVersion)
+                .AddString("boot_id", RestBootId)
                 .AddString("id", commandId)
                 .AddBool("ok", ok)
                 .AddString("code", code)

--- a/software/nanoFramework/CubleyControl/Program.Commands.Rest.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Rest.cs
@@ -11,6 +11,11 @@ namespace CubleyControl
         private const string RestCommandPath = "/api/v2/commands";
         private const int RestHeaderMaxLength = 768;
         private const int RestSocketTimeoutMs = 2000;
+        private const string RestJobsPathPrefix = "/api/v2/jobs/";
+        private const string RestHealthPath = "/api/v2/health";
+        private const string RestPositionerStatePath = "/api/v2/state/positioner";
+        private const string RestLnbStatePath = "/api/v2/state/lnb";
+        private static readonly string RestBootId = Guid.NewGuid().ToString();
 
         private static void RestLoop()
         {
@@ -105,6 +110,12 @@ namespace CubleyControl
 
             string method = headers.Substring(0, firstSpace);
             string path = headers.Substring(firstSpace + 1, secondSpace - firstSpace - 1);
+            if (method == "GET")
+            {
+                HandleRestGetRequest(client, path);
+                return;
+            }
+
             if (path != RestCommandPath)
             {
                 WriteRestResponse(client, 404, null);
@@ -137,8 +148,82 @@ namespace CubleyControl
                 received += count;
             }
 
-            string responseBody = ProcessApiCommand(AsciiBytesToString(request, bodyOffset, contentLength));
+            string responseBody;
+            lock (_commandLock)
+            {
+                responseBody = ProcessApiCommand(AsciiBytesToString(request, bodyOffset, contentLength));
+            }
             WriteRestResponse(client, 200, responseBody);
+        }
+
+        private static void HandleRestGetRequest(Socket client, string path)
+        {
+            if (path == RestHealthPath)
+            {
+                string health = new JsonBuilder()
+                    .AddString("status", "ok")
+                    .AddString("firmware_version", BuildInfo.Version)
+                    .Build();
+                WriteRestResponse(client, 200, BuildRestQueryResponse(true, "ok", health, null));
+                return;
+            }
+
+            if (path == RestPositionerStatePath)
+            {
+                WriteRestResponse(client, 200, BuildRestQueryResponse(true, "ok", BuildDiseqcStateJson(), null));
+                return;
+            }
+
+            if (path == RestLnbStatePath)
+            {
+                WriteRestResponse(client, 200, BuildRestQueryResponse(true, "ok", BuildLnbStateJson(), null));
+                return;
+            }
+
+            if (path.StartsWith(RestJobsPathPrefix))
+            {
+                int jobId;
+                string text = path.Substring(RestJobsPathPrefix.Length);
+                if (!TryParsePositiveInt(text, out jobId))
+                {
+                    WriteRestResponse(client, 400, BuildRestQueryResponse(false, "validation_error", null, "job must be a positive integer"));
+                    return;
+                }
+
+                string job = BuildDiseqcJobJson(jobId);
+                if (job == "null")
+                {
+                    WriteRestResponse(client, 404, BuildRestQueryResponse(false, "not_found", null, "job is unknown or has been evicted"));
+                    return;
+                }
+
+                WriteRestResponse(client, 200, BuildRestQueryResponse(true, "ok", job, null));
+                return;
+            }
+
+            WriteRestResponse(client, 404, BuildRestQueryResponse(false, "not_found", null, "resource not found"));
+        }
+
+        private static string BuildRestQueryResponse(bool ok, string code, string data, string message)
+        {
+            JsonBuilder builder = new JsonBuilder()
+                .AddInt("v", DeviceContractVersion)
+                .AddString("boot_id", RestBootId)
+                .AddBool("ok", ok)
+                .AddString("code", code)
+                .AddLong("ts_ms", Environment.TickCount64);
+
+            if (message != null)
+            {
+                builder.AddString("msg", message);
+            }
+
+            if (data != null)
+            {
+                builder.AddRaw("data", data);
+            }
+
+            return builder.Build();
         }
 
         private static int FindRestBodyOffset(byte[] request, int length)

--- a/software/nanoFramework/CubleyControl/Program.Commands.Rest.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Rest.cs
@@ -170,7 +170,13 @@ namespace CubleyControl
 
             if (path == RestPositionerStatePath)
             {
-                WriteRestResponse(client, 200, BuildRestQueryResponse(true, "ok", BuildDiseqcStateJson(), null));
+                string state;
+                lock (_commandLock)
+                {
+                    state = BuildDiseqcStateJson();
+                }
+
+                WriteRestResponse(client, 200, BuildRestQueryResponse(true, "ok", state, null));
                 return;
             }
 

--- a/software/nanoFramework/CubleyControl/Program.Jobs.cs
+++ b/software/nanoFramework/CubleyControl/Program.Jobs.cs
@@ -11,19 +11,20 @@ namespace CubleyControl
         //
         // There is deliberately no "succeeded" state: a DiSEqC 1.2 positioner
         // reports no arrival indication, so the device only ever knows what it
-        // transmitted and how much time has elapsed. JobStateReleased records a
-        // client's assertion that motion finished, not a device observation.
+        // transmitted and how much time has elapsed. JobStateCompleted records
+        // a client's assertion that motion finished, not a device observation.
         private const int DiseqcJobHistoryDepth = 4;
         private const string JobStateRunning = "running";
         private const string JobStateHalted = "halted";
         private const string JobStateTimeout = "timeout";
         private const string JobStateTimeoutHaltFailed = "timeout_halt_failed";
-        private const string JobStateReleased = "released";
+        private const string JobStateCompleted = "completed";
 
         private static readonly object _diseqcJobLock = new object();
         private static readonly int[] _diseqcJobIds = new int[DiseqcJobHistoryDepth];
         private static readonly string[] _diseqcJobOps = new string[DiseqcJobHistoryDepth];
         private static readonly string[] _diseqcJobStates = new string[DiseqcJobHistoryDepth];
+        private static readonly string[] _diseqcJobVerifications = new string[DiseqcJobHistoryDepth];
         private static readonly string[] _diseqcJobDetails = new string[DiseqcJobHistoryDepth];
         private static readonly long[] _diseqcJobDeadlines = new long[DiseqcJobHistoryDepth];
         private static readonly int[] _diseqcJobTimeouts = new int[DiseqcJobHistoryDepth];
@@ -60,6 +61,7 @@ namespace CubleyControl
                 _diseqcJobIds[slot] = _diseqcNextJobId;
                 _diseqcJobOps[slot] = operation;
                 _diseqcJobStates[slot] = JobStateRunning;
+                _diseqcJobVerifications[slot] = "pending";
                 _diseqcJobDetails[slot] = string.Empty;
                 _diseqcJobTimeouts[slot] = timeoutMs;
                 _diseqcJobDeadlines[slot] = Environment.TickCount64 +
@@ -76,6 +78,11 @@ namespace CubleyControl
         /// from terminating a newer movement.
         /// </summary>
         private static bool TryEndDiseqcJob(int jobId, string state, string detail)
+        {
+            return TryEndDiseqcJob(jobId, state, "none", detail);
+        }
+
+        private static bool TryEndDiseqcJob(int jobId, string state, string verification, string detail)
         {
             bool ended;
             lock (_diseqcJobLock)
@@ -96,6 +103,7 @@ namespace CubleyControl
                 }
 
                 _diseqcJobStates[slot] = state;
+                _diseqcJobVerifications[slot] = verification;
                 _diseqcJobDetails[slot] = detail == null ? string.Empty : detail;
                 _diseqcJobDeadlines[slot] = 0;
                 _diseqcActiveJobId = 0;
@@ -160,12 +168,14 @@ namespace CubleyControl
             int jobId,
             out string operation,
             out string state,
+            out string verification,
             out int remainingMs,
             out int timeoutMs,
             out string detail)
         {
             operation = "idle";
             state = string.Empty;
+            verification = "none";
             remainingMs = 0;
             timeoutMs = 0;
             detail = string.Empty;
@@ -180,6 +190,7 @@ namespace CubleyControl
 
                 operation = _diseqcJobOps[slot];
                 state = _diseqcJobStates[slot];
+                verification = _diseqcJobVerifications[slot];
                 timeoutMs = _diseqcJobTimeouts[slot];
                 detail = _diseqcJobDetails[slot];
                 remainingMs = state == JobStateRunning
@@ -240,9 +251,10 @@ namespace CubleyControl
             motionId = reportedJobId;
 
             string state;
+            string verification;
             int timeoutMs;
             string detail;
-            if (!TryGetDiseqcJobSnapshot(reportedJobId, out operation, out state, out remainingMs, out timeoutMs, out detail))
+            if (!TryGetDiseqcJobSnapshot(reportedJobId, out operation, out state, out verification, out remainingMs, out timeoutMs, out detail))
             {
                 operation = "idle";
                 remainingMs = 0;
@@ -264,10 +276,11 @@ namespace CubleyControl
         {
             string operation;
             string state;
+            string verification;
             int remainingMs;
             int timeoutMs;
             string detail;
-            if (!TryGetDiseqcJobSnapshot(jobId, out operation, out state, out remainingMs, out timeoutMs, out detail))
+            if (!TryGetDiseqcJobSnapshot(jobId, out operation, out state, out verification, out remainingMs, out timeoutMs, out detail))
             {
                 return "null";
             }
@@ -276,6 +289,7 @@ namespace CubleyControl
                 .AddInt("job", jobId)
                 .AddString("op", operation)
                 .AddString("state", state)
+                .AddString("verification", verification)
                 .AddInt("remaining_ms", remainingMs)
                 .AddInt("timeout_ms", timeoutMs)
                 .AddString("detail", detail)
@@ -291,25 +305,40 @@ namespace CubleyControl
                 lastTerminalJobId = _diseqcLastTerminalJobId;
             }
 
-            return new JsonBuilder()
+            JsonBuilder builder = new JsonBuilder()
                 .AddInt("v", DeviceContractVersion)
                 .AddString("sub", "diseqc")
                 .AddString("comp", "state")
                 .AddBool("busy", activeJobId != 0)
                 .AddInt("timeout_ms", _diseqcMotionTimeoutMs)
                 .AddRaw("active", activeJobId == 0 ? "null" : BuildDiseqcJobJson(activeJobId))
-                .AddRaw("last", lastTerminalJobId == 0 ? "null" : BuildDiseqcJobJson(lastTerminalJobId))
-                .Build();
+                .AddRaw("last", lastTerminalJobId == 0 ? "null" : BuildDiseqcJobJson(lastTerminalJobId));
+
+            lock (_diseqcMotionLock)
+            {
+                builder
+                    .AddString("position_confidence", _diseqcPositionEstimate.Confidence)
+                    .AddRaw("estimated_angle_deg", _diseqcPositionEstimate.HasEstimate
+                        ? Json.Quote(FormatSignedDiseqcAngle(_diseqcPositionEstimate.EstimatedAngleMicrodegrees))
+                        : "null")
+                    .AddString("position_source", _diseqcPositionEstimate.Source)
+                    .AddRaw("pending_target_deg", _diseqcPositionEstimate.HasPendingTarget
+                        ? Json.Quote(FormatSignedDiseqcAngle(_diseqcPositionEstimate.PendingTargetMicrodegrees))
+                        : "null");
+            }
+
+            return builder.Build();
         }
 
         private static string BuildDiseqcJobEventJson(string transition, int jobId)
         {
             string operation;
             string state;
+            string verification;
             int remainingMs;
             int timeoutMs;
             string detail;
-            TryGetDiseqcJobSnapshot(jobId, out operation, out state, out remainingMs, out timeoutMs, out detail);
+            TryGetDiseqcJobSnapshot(jobId, out operation, out state, out verification, out remainingMs, out timeoutMs, out detail);
 
             return new JsonBuilder()
                 .AddInt("v", DeviceContractVersion)
@@ -320,6 +349,7 @@ namespace CubleyControl
                 .AddInt("job", jobId)
                 .AddString("op", operation)
                 .AddString("state", state)
+                .AddString("verification", verification)
                 .AddInt("remaining_ms", remainingMs)
                 .Build();
         }

--- a/software/nanoFramework/CubleyControl/Program.LnbHealth.cs
+++ b/software/nanoFramework/CubleyControl/Program.LnbHealth.cs
@@ -26,6 +26,41 @@ namespace CubleyControl
         private static int _lnbHealthD4;
         private static int _lnbHealthPublishElapsedMs;
 
+        private static string BuildLnbStateJson()
+        {
+            lock (_lnbIoLock)
+            {
+                JsonBuilder builder = new JsonBuilder()
+                    .AddInt("v", DeviceContractVersion)
+                    .AddString("sub", "lnb")
+                    .AddString("comp", "state")
+                    .AddString("status", _lnbHealthState)
+                    .AddString("communication", !_lnbHealthHasResult ? "unknown" : (_lnbHealthCommsOk ? "ok" : "error"))
+                    .AddInt("health_failures", _lnbHealthConsecutiveFailures)
+                    .AddInt("health_rc", _lnbHealthResult)
+                    .AddString("s1", ToHexU8(_lnbHealthS1))
+                    .AddString("s2", ToHexU8(_lnbHealthS2))
+                    .AddString("d1", ToHexU8(_lnbHealthD1))
+                    .AddString("d2", ToHexU8(_lnbHealthD2))
+                    .AddString("d3", ToHexU8(_lnbHealthD3))
+                    .AddString("d4", ToHexU8(_lnbHealthD4))
+                    .AddBool("fault", _lnbFaultAsserted)
+                    .AddString("monitor", _lnbFaultReady ? "ready" : "unavailable")
+                    .AddString("initialization", LnbStatusToToken(_lnbInitStatus));
+
+                if (_lnbInitStatus == (int)LNBH26.Status.Ok)
+                {
+                    builder
+                        .AddString("a_polarization", PolarizationToText(LNBH26.NativeGetPolarizationForChannel(LnbChannelA)))
+                        .AddString("a_band", BandToText(LNBH26.NativeGetBandForChannel(LnbChannelA)))
+                        .AddString("b_polarization", PolarizationToText(LNBH26.NativeGetPolarizationForChannel(1)))
+                        .AddString("b_band", BandToText(LNBH26.NativeGetBandForChannel(1)));
+                }
+
+                return builder.Build();
+            }
+        }
+
         private static void LnbHealthLoop()
         {
             int delayMs = LnbHealthIntervalMs;

--- a/software/nanoFramework/CubleyDiseqc.Managed/DiseqcPositionEstimate.cs
+++ b/software/nanoFramework/CubleyDiseqc.Managed/DiseqcPositionEstimate.cs
@@ -84,6 +84,16 @@ namespace Cubley.Diseqc
 
         public bool CompletePending()
         {
+            return CompletePending("estimated");
+        }
+
+        public bool CompletePendingAsRfVerified()
+        {
+            return CompletePending("rf_verified");
+        }
+
+        private bool CompletePending(string confidence)
+        {
             if (!HasPendingTarget)
             {
                 Invalidate();
@@ -92,7 +102,7 @@ namespace Cubley.Diseqc
 
             HasEstimate = true;
             EstimatedAngleMicrodegrees = PendingTargetMicrodegrees;
-            Confidence = "estimated";
+            Confidence = confidence;
             Source = PendingSource;
             ClearPending();
             return true;

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/DiseqcPositionEstimateTests.cs
@@ -22,7 +22,20 @@ public sealed class DiseqcPositionEstimateTests
     }
 
     [Fact]
-    public void RestGotoAngleAdoptsOffsetAdjustedEncodedTargetOnRelease()
+    public void RfVerificationPromotesPendingTargetWithVerifiedConfidence()
+    {
+        var estimate = new DiseqcPositionEstimate();
+        estimate.BeginGotoAngular(DiseqcMotorDirection.East, 28_200_000);
+
+        Assert.True(estimate.CompletePendingAsRfVerified());
+        Assert.Equal(28_200_000, estimate.EstimatedAngleMicrodegrees);
+        Assert.Equal("rf_verified", estimate.Confidence);
+        Assert.Equal("goto_x", estimate.Source);
+        Assert.False(estimate.HasPendingTarget);
+    }
+
+    [Fact]
+    public void RestGotoAngleAdoptsOffsetAdjustedEncodedTargetOnCompletion()
     {
         bool success = DiseqcCommandBuilder.TryBuildGotoAngularPosition(
             DiseqcMotorDirection.East,


### PR DESCRIPTION
Closes #140

## Summary

- add REST health, LNB state, positioner state, and retained job query endpoints
- add per-boot identity to command and query responses
- replace the draft `positioner.release` operation with `positioner.complete`
- record `estimated`, `rf_verified`, or `verification_failed` completion independently from job lifecycle state
- promote only the device-owned encoded pending target for RF verification
- update the v2 contract and developer guide

## Validation

- `dotnet test tests/DiSEqC_Control.Tests/DiSEqC_Control.Tests.csproj --no-restore` (29 passed)
- `./toolchain/build-CubleyControl.sh build --project CubleyControl/CubleyControl.nfproj --configuration Debug`
- interop guard and deterministic deployment bundle validation passed

## Remaining validation

The REST listener and RF-verified completion flow still need exercise on target hardware. MQTT remains unchanged and will be removed separately after this API is validated.