### PR TITLE
Persist DiSEqC angle limits

### DIFF
--- a/docs/software/CONFIGURATION.md
+++ b/docs/software/CONFIGURATION.md
@@ -85,9 +85,11 @@ shown.
 
 ## Runtime Overrides
 
-Operational `diseqc angle-limits` and `diseqc step-calibration` commands change
-RAM state only. Reboot restores committed values. The fixed GoToX offset is
-changed only in configuration mode.
+Operational `diseqc angle-limits <east> <west>` and `diseqc angle-limits off`
+write the application record immediately and survive reboot. The runtime limits
+change only after the write is verified. Operational `diseqc step-calibration`
+commands remain RAM-only, and the fixed GoToX offset is changed only in
+configuration mode.
 
 The signed offset is applied before direction-specific limit checking and GoToX
 encoding. For example, `diseqc fixed-offset west 3.38` changes a requested

--- a/docs/software/CONFIGURATION_STORAGE.md
+++ b/docs/software/CONFIGURATION_STORAGE.md
@@ -37,9 +37,13 @@ dw_step=<west step size in microdegrees>
 d_offset=<signed GoToX offset in microdegrees>
 ```
 
-Unknown keys, malformed values, invalid field combinations, a different schema
-version, and invalid magic, length, or CRC cause the record to be rejected. The
-application then uses schema-4 defaults.
+Valid schema-3 records are migrated in memory by retaining hostname, angle
+limits, step calibration, GoToX offset, and generation. Retired MQTT fields are
+discarded. Schema 4 is written on the next application configuration update.
+
+Unknown keys, malformed retained values, invalid field combinations, an
+unsupported schema version, and invalid magic, length, or CRC cause the record
+to be rejected. The application then uses schema-4 defaults.
 
 ## Active Internal Flash Backend
 
@@ -53,8 +57,8 @@ record, erases the sector, writes the complete image, and verifies the record.
 This preserves the nanoFramework network configuration block.
 
 Sector erase makes this backend non-atomic across power loss. CRC validation
-detects an incomplete record. Writes occur only after an explicit USB CDC
-configuration commit.
+detects an incomplete record. Writes occur after an explicit USB CDC
+configuration commit or an operational `diseqc angle-limits` update.
 
 ## Future Backend
 

--- a/docs/software/INTERFACE_COMMAND_MAP_V1.md
+++ b/docs/software/INTERFACE_COMMAND_MAP_V1.md
@@ -275,9 +275,9 @@ angle before direction-specific limit checking and GoToX encoding. For example,
 | `diseqc store <position>` | Store the current physical position in motor slot `1..60` with command `0x6A`. |
 | `diseqc recalculate` | Send the basic `0x6F 0x00` Set/Recalculate Positions command. For the TM-2300 receiver workflow this re-synchronizes the selected stored position and shifts the others; the DiSEqC specification defines parameter `0x00` as manufacturer-specific, so verify this behavior on the installed motor before relying on it. |
 | `diseqc motor-limit <east\|west\|off>` | Send motor-internal limit command `0x66`, `0x67`, or `0x63`. East or west records the motor's current physical position as that limit. This does not configure Cubley's angular safety limits. |
-| `diseqc angle-limits <east_degrees> <west_degrees>` | Set positive, direction-specific runtime limits in the protocol range through 180 degrees. Rejected during motion. The operator must choose values strictly inside the motor's physically adjusted hardware stops. |
+| `diseqc angle-limits <east_degrees> <west_degrees>` | Persist positive, direction-specific limits in the protocol range through 180 degrees and apply them after verified storage. Rejected during motion. The operator must choose values strictly inside the motor's physically adjusted hardware stops. |
 | `diseqc angle-limits status` | Show whether angular motion is armed and both direction limits. |
-| `diseqc angle-limits off` | Temporarily disable angular movement. Persisted limits are loaded again after reboot. Rejected during motion. |
+| `diseqc angle-limits off` | Persist disabled angular movement and apply it after verified storage. Rejected during motion. |
 | `diseqc step-calibration <east_deg_per_step> <west_deg_per_step>` | Temporarily set direction-specific step sizes with up to six decimal places. Persisted calibration is loaded again after reboot. |
 | `diseqc step-calibration status` | Show step calibration and position-estimate state. |
 | `diseqc step-calibration off` | Disable step calibration. |

--- a/docs/software/INTERFACE_COMMAND_MAP_V1.md
+++ b/docs/software/INTERFACE_COMMAND_MAP_V1.md
@@ -278,7 +278,7 @@ angle before direction-specific limit checking and GoToX encoding. For example,
 | `diseqc angle-limits <east_degrees> <west_degrees>` | Persist positive, direction-specific limits in the protocol range through 180 degrees and apply them after verified storage. Rejected during motion. The operator must choose values strictly inside the motor's physically adjusted hardware stops. |
 | `diseqc angle-limits status` | Show whether angular motion is armed and both direction limits. |
 | `diseqc angle-limits off` | Persist disabled angular movement and apply it after verified storage. Rejected during motion. |
-| `diseqc step-calibration <east_deg_per_step> <west_deg_per_step>` | Temporarily set direction-specific step sizes with up to six decimal places. Persisted calibration is loaded again after reboot. |
+| `diseqc step-calibration <east_deg_per_step> <west_deg_per_step>` | Temporarily set direction-specific step sizes with up to six decimal places. Operational changes are RAM-only; values committed in USB configuration mode are loaded again after reboot. |
 | `diseqc step-calibration status` | Show step calibration and position-estimate state. |
 | `diseqc step-calibration off` | Disable step calibration. |
 | `diseqc step <east\|west> <steps>` | Move `1..128` steps. |

--- a/software/nanoFramework/CubleyControl/ApplicationConfiguration.cs
+++ b/software/nanoFramework/CubleyControl/ApplicationConfiguration.cs
@@ -76,6 +76,20 @@ namespace CubleyControl
 
         public static bool TryParsePayload(string payload, out ApplicationConfiguration configuration, out string error)
         {
+            return TryParsePayload(payload, false, out configuration, out error);
+        }
+
+        public static bool TryParseLegacyPayload(string payload, out ApplicationConfiguration configuration, out string error)
+        {
+            return TryParsePayload(payload, true, out configuration, out error);
+        }
+
+        private static bool TryParsePayload(
+            string payload,
+            bool allowRetiredTransportFields,
+            out ApplicationConfiguration configuration,
+            out string error)
+        {
             configuration = CreateDefaults();
             if (string.IsNullOrEmpty(payload))
             {
@@ -146,6 +160,10 @@ namespace CubleyControl
                     }
                     configuration.DiseqcGotoOffsetMicrodegrees = number;
                 }
+                else if (allowRetiredTransportFields && IsRetiredTransportField(key))
+                {
+                    continue;
+                }
                 else
                 {
                     error = "payload_key_unknown";
@@ -154,6 +172,14 @@ namespace CubleyControl
             }
 
             return configuration.TryValidate(out error);
+        }
+
+        private static bool IsRetiredTransportField(string key)
+        {
+            return key == "enabled" || key == "broker" || key == "port" ||
+                key == "client_id" || key == "username" || key == "password" ||
+                key == "topic_prefix" || key == "keepalive_seconds" ||
+                key == "reconnect_seconds";
         }
 
         private static bool IsValidDiseqcPair(int eastMicrodegrees, int westMicrodegrees)

--- a/software/nanoFramework/CubleyControl/ApplicationConfigurationRecord.cs
+++ b/software/nanoFramework/CubleyControl/ApplicationConfigurationRecord.cs
@@ -7,6 +7,7 @@ namespace CubleyControl
         public const int RecordSize = 512;
         public const int HeaderSize = 16;
         public const byte SchemaVersion = 4;
+        private const byte LegacySchemaVersion = 3;
 
         public static bool TryEncode(ApplicationConfiguration configuration, uint generation, out byte[] record, out string error)
         {
@@ -61,7 +62,8 @@ namespace CubleyControl
                 return false;
             }
 
-            if (record[4] != SchemaVersion)
+            byte schemaVersion = record[4];
+            if (schemaVersion != SchemaVersion && schemaVersion != LegacySchemaVersion)
             {
                 error = "record_version_unsupported";
                 return false;
@@ -84,7 +86,9 @@ namespace CubleyControl
 
             generation = ReadUInt32(record, 8);
             string text = AsciiBytesToString(payload);
-            return ApplicationConfiguration.TryParsePayload(text, out configuration, out error);
+            return schemaVersion == LegacySchemaVersion
+                ? ApplicationConfiguration.TryParseLegacyPayload(text, out configuration, out error)
+                : ApplicationConfiguration.TryParsePayload(text, out configuration, out error);
         }
 
         private static byte[] AsciiStringToBytes(string text)

--- a/software/nanoFramework/CubleyControl/Program.ApplicationConfiguration.cs
+++ b/software/nanoFramework/CubleyControl/Program.ApplicationConfiguration.cs
@@ -45,5 +45,53 @@ namespace CubleyControl
                     ? string.Empty
                     : " code=" + SanitizeToken(_applicationConfigurationError)));
         }
+
+        private static bool TryPersistDiseqcAngleLimits(
+            int eastMicrodegrees,
+            int westMicrodegrees,
+            out string error)
+        {
+            ApplicationConfiguration candidate;
+            uint currentGeneration;
+            lock (_applicationConfigurationLock)
+            {
+                candidate = _applicationConfiguration.Clone();
+                currentGeneration = _applicationConfigurationGeneration;
+            }
+
+            candidate.DiseqcEastLimitMicrodegrees = eastMicrodegrees;
+            candidate.DiseqcWestLimitMicrodegrees = westMicrodegrees;
+            if (!candidate.TryValidate(out error))
+            {
+                return false;
+            }
+
+            uint savedGeneration;
+            if (!TryPersistApplicationConfiguration(
+                candidate,
+                currentGeneration,
+                out savedGeneration,
+                out error))
+            {
+                return false;
+            }
+
+            lock (_applicationConfigurationLock)
+            {
+                _applicationConfiguration = candidate;
+                _applicationConfigurationGeneration = savedGeneration;
+            }
+
+            _pendingApplicationConfiguration = candidate.Clone();
+            _applicationConfigurationDirty = false;
+            _applicationConfigurationSource = _applicationConfigurationStorage.Source;
+            _applicationConfigurationError = string.Empty;
+            lock (_diseqcMotionLock)
+            {
+                _diseqcEastTravelLimitMicrodegrees = eastMicrodegrees;
+                _diseqcWestTravelLimitMicrodegrees = westMicrodegrees;
+            }
+            return true;
+        }
     }
 }

--- a/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
+++ b/software/nanoFramework/CubleyControl/Program.Commands.Diseqc.cs
@@ -625,8 +625,18 @@ namespace CubleyControl
                     return;
                 }
 
-                _diseqcEastTravelLimitMicrodegrees = 0;
-                _diseqcWestTravelLimitMicrodegrees = 0;
+                string error;
+                if (!TryPersistDiseqcAngleLimits(0, 0, out error))
+                {
+                    WriteCommandResult(
+                        reqId,
+                        false,
+                        "persist_failed",
+                        "diseqc angle-limits persistence failed",
+                        "reason=" + SanitizeToken(error));
+                    return;
+                }
+
                 WriteCommandResult(reqId, true, "ok", "diseqc angle-limits disabled", BuildDiseqcTravelLimitsData());
                 return;
             }
@@ -668,8 +678,18 @@ namespace CubleyControl
                 return;
             }
 
-            _diseqcEastTravelLimitMicrodegrees = eastMicrodegrees;
-            _diseqcWestTravelLimitMicrodegrees = westMicrodegrees;
+            string persistError;
+            if (!TryPersistDiseqcAngleLimits(eastMicrodegrees, westMicrodegrees, out persistError))
+            {
+                WriteCommandResult(
+                    reqId,
+                    false,
+                    "persist_failed",
+                    "diseqc angle-limits persistence failed",
+                    "reason=" + SanitizeToken(persistError));
+                return;
+            }
+
             WriteCommandResult(reqId, true, "ok", "diseqc angle-limits", BuildDiseqcTravelLimitsData());
         }
 

--- a/software/nanoFramework/tests/DiSEqC_Control.Tests/ApplicationConfigurationRecordTests.cs
+++ b/software/nanoFramework/tests/DiSEqC_Control.Tests/ApplicationConfigurationRecordTests.cs
@@ -35,11 +35,61 @@ public sealed class ApplicationConfigurationRecordTests
     }
 
     [Fact]
-    public void PreviousSchemaRecordIsRejected()
+    public void PreviousSchemaRecordPreservesApplicationFields()
     {
         ApplicationConfiguration expected = ApplicationConfiguration.CreateDefaults();
+        expected.Hostname = "cubley-legacy";
+        expected.DiseqcEastLimitMicrodegrees = 36_600_000;
+        expected.DiseqcWestLimitMicrodegrees = 40_000_000;
+        expected.DiseqcEastStepMicrodegrees = 112_658;
+        expected.DiseqcWestStepMicrodegrees = 113_000;
+        expected.DiseqcGotoOffsetMicrodegrees = -3_380_000;
         Assert.True(ApplicationConfigurationRecord.TryEncode(expected, 3, out byte[] record, out string encodeError), encodeError);
         record[4] = 3;
+
+        Assert.True(ApplicationConfigurationRecord.TryDecode(record, out ApplicationConfiguration actual, out uint generation, out string decodeError), decodeError);
+        Assert.Equal((uint)3, generation);
+        Assert.Equal(expected.ToPayload(), actual.ToPayload());
+    }
+
+    [Fact]
+    public void LegacyPayloadDropsRetiredTransportFields()
+    {
+        const string payload =
+            "enabled=true\n" +
+            "broker=example.net\n" +
+            "port=1883\n" +
+            "client_id=legacy\n" +
+            "hostname=cubley-legacy\n" +
+            "username=user\n" +
+            "password=secret\n" +
+            "topic_prefix=diseqc\n" +
+            "keepalive_seconds=60\n" +
+            "reconnect_seconds=5\n" +
+            "de_lim=36600000\n" +
+            "dw_lim=40000000\n" +
+            "de_step=112658\n" +
+            "dw_step=113000\n" +
+            "d_offset=-3380000";
+
+        Assert.True(ApplicationConfiguration.TryParseLegacyPayload(
+            payload,
+            out ApplicationConfiguration actual,
+            out string error), error);
+        Assert.Equal("cubley-legacy", actual.Hostname);
+        Assert.Equal(36_600_000, actual.DiseqcEastLimitMicrodegrees);
+        Assert.Equal(40_000_000, actual.DiseqcWestLimitMicrodegrees);
+        Assert.Equal(112_658, actual.DiseqcEastStepMicrodegrees);
+        Assert.Equal(113_000, actual.DiseqcWestStepMicrodegrees);
+        Assert.Equal(-3_380_000, actual.DiseqcGotoOffsetMicrodegrees);
+    }
+
+    [Fact]
+    public void UnsupportedSchemaRecordIsRejected()
+    {
+        ApplicationConfiguration expected = ApplicationConfiguration.CreateDefaults();
+        Assert.True(ApplicationConfigurationRecord.TryEncode(expected, 2, out byte[] record, out string encodeError), encodeError);
+        record[4] = 2;
 
         Assert.False(ApplicationConfigurationRecord.TryDecode(record, out _, out _, out string decodeError));
         Assert.Equal("record_version_unsupported", decodeError);


### PR DESCRIPTION
Closes #146

## Summary

- persist operational `diseqc angle-limits EAST WEST` updates through verified application storage
- persist `diseqc angle-limits off` so disabled angular movement survives reboot
- apply runtime limits only after storage write and readback succeed
- migrate hostname and DiSEqC positioning fields from valid schema-3 records while discarding retired MQTT fields
- preserve temporary runtime step calibration when limits are updated
- update configuration and command documentation

## Validation

- managed tests: 31 passed
- focused application configuration tests: 5 passed
- Debug managed firmware build: passed
- interop guard and checksum validation: passed
- deployment manifest: passed
- deterministic bundle: 13 records, 186,976 bytes
- `git diff --check`: passed

## Hardware validation remaining

Set limits with the operational USB command, reboot, confirm `diseqc angle-limits status`, then exercise `diseqc goto-angle` within the configured limits.